### PR TITLE
Add mock categories page

### DIFF
--- a/client-src/categories/components/categories-list/index.js
+++ b/client-src/categories/components/categories-list/index.js
@@ -1,11 +1,17 @@
 import React from 'react';
 import CategoryListItem from '../category-list-item';
 
-export default function CategoriesList({categories, categoriesActions, currentlyDeleting}) {
+export default function CategoriesList(props) {
+  const {
+    categories, categoriesActions,
+    currentlyDeleting, isOnline
+  } = props;
+
   return (
     <ul className="categories-list resource-list">
       {categories.map(category => (
         <CategoryListItem
+          isOnline={isOnline}
           category={category}
           key={category.id}
           categoriesActions={categoriesActions}

--- a/client-src/categories/components/categories-list/index.js
+++ b/client-src/categories/components/categories-list/index.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import CategoryListItem from '../category-list-item';
 
-export default function CategoriesList({categories}) {
+export default function CategoriesList({categories, categoriesActions, currentlyDeleting}) {
   return (
     <ul className="categories-list resource-list">
       {categories.map(category => (
-        <CategoryListItem category={category} key={category.id}/>
+        <CategoryListItem
+          category={category}
+          key={category.id}
+          categoriesActions={categoriesActions}
+          currentlyDeleting={currentlyDeleting}/>
       ))}
     </ul>
   );

--- a/client-src/categories/components/categories-list/index.js
+++ b/client-src/categories/components/categories-list/index.js
@@ -3,7 +3,7 @@ import CategoryListItem from '../category-list-item';
 
 export default function CategoriesList(props) {
   const {
-    categories, categoriesActions,
+    categories, categoriesActions, alertActions,
     currentlyDeleting, isOnline
   } = props;
 
@@ -14,6 +14,7 @@ export default function CategoriesList(props) {
           isOnline={isOnline}
           category={category}
           key={category.id}
+          alertActions={alertActions}
           categoriesActions={categoriesActions}
           currentlyDeleting={currentlyDeleting}/>
       ))}

--- a/client-src/categories/components/categories-list/index.js
+++ b/client-src/categories/components/categories-list/index.js
@@ -3,7 +3,7 @@ import CategoryListItem from '../category-list-item';
 
 export default function CategoriesList(props) {
   const {
-    categories, categoriesActions, alertActions,
+    categories, categoriesActions,
     currentlyDeleting, isOnline
   } = props;
 
@@ -14,7 +14,6 @@ export default function CategoriesList(props) {
           isOnline={isOnline}
           category={category}
           key={category.id}
-          alertActions={alertActions}
           categoriesActions={categoriesActions}
           currentlyDeleting={currentlyDeleting}/>
       ))}

--- a/client-src/categories/components/categories-list/index.js
+++ b/client-src/categories/components/categories-list/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import CategoryListItem from '../category-list-item';
+
+export default function CategoriesList({categories}) {
+  return (
+    <ul className="categories-list resource-list">
+      {categories.map(category => (
+        <CategoryListItem category={category} key={category.id}/>
+      ))}
+    </ul>
+  );
+}

--- a/client-src/categories/components/category-list-item/category-list-item.styl
+++ b/client-src/categories/components/category-list-item/category-list-item.styl
@@ -1,0 +1,23 @@
+.category-list-item
+  display flex
+  height 35px
+  border-bottom 1px solid #eee
+
+  .category-list-item-emoji,
+  .category-list-item-label,
+  .delete-category
+    height 35px
+    line-height 35px
+
+  .category-list-item-emoji
+    margin-right 15px
+    width 50px
+    flex 0
+
+  .category-list-item-label
+    margin-right 15px
+    flex 1
+
+  .delete-category
+    width 50px
+    flex 0

--- a/client-src/categories/components/category-list-item/category-list-item.styl
+++ b/client-src/categories/components/category-list-item/category-list-item.styl
@@ -4,20 +4,26 @@
   border-bottom 1px solid #eee
 
   .category-list-item-emoji,
-  .category-list-item-label,
-  .delete-category
+  .category-list-item-label
+    cursor pointer
     height 35px
     line-height 35px
 
   .category-list-item-emoji
-    margin-right 15px
-    width 50px
+    padding-left 15px
+    // There's 15px of space between the emoji and the text. The space
+    // is divided evenly between the emoji and the text, with a 3px margin
+    // 6px + 6px + 3px = 15px
+    padding-right 6px
+    margin-right 3px
+    width 37px
+    min-width 37px
     flex 0
 
   .category-list-item-label
+    ellipsis()
+    // There's 15px of space between the emoji and the text. The space
+    // is divided evenly between the emoji and the text, with a 3px margin
+    // 6px + 6px + 3px = 15px
+    padding 0 6px
     margin-right 15px
-    flex 1
-
-  .delete-category
-    width 50px
-    flex 0

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -2,13 +2,17 @@ import _ from 'lodash';
 import React from 'react';
 
 export default function CategoryListItem(props) {
-  const {category, categoriesActions, currentlyDeleting} = props;
+  const {
+    category, categoriesActions,
+    currentlyDeleting, isOnline
+  } = props;
 
   function onClickDelete() {
     categoriesActions.deleteCategory(category.id);
   }
 
   const isDeleting = _.includes(currentlyDeleting, category.id);
+  const deleteIsDisabled = isDeleting || !isOnline;
 
   return (
     <li className="resource-list-item category-list-item">
@@ -21,7 +25,7 @@ export default function CategoryListItem(props) {
       <button
         className="resource-list-item-delete"
         onClick={onClickDelete}
-        disabled={isDeleting}>
+        disabled={deleteIsDisabled}>
         Delete
       </button>
     </li>

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 export default function CategoryListItem(props) {
   const {
-    category, categoriesActions,
+    category, categoriesActions, alertActions,
     currentlyDeleting, isOnline
   } = props;
 

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import React from 'react';
 
 export default function CategoryListItem(props) {

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -3,7 +3,7 @@ import React from 'react';
 
 export default function CategoryListItem(props) {
   const {
-    category, categoriesActions, alertActions,
+    category, categoriesActions,
     currentlyDeleting, isOnline
   } = props;
 

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -1,6 +1,14 @@
 import React from 'react';
 
-export default function CategoryListItem({category}) {
+export default function CategoryListItem(props) {
+  const {category, categoriesActions, currentlyDeleting} = props;
+
+  function onClickDelete() {
+    categoriesActions.deleteCategory(category.id);
+  }
+
+  const isDeleting = _.includes(currentlyDeleting, category.id);
+
   return (
     <li className="resource-list-item category-list-item">
       <span className="category-list-item-emoji">
@@ -9,7 +17,10 @@ export default function CategoryListItem({category}) {
       <span className="category-list-item-label">
         {category.label}
       </span>
-      <button className="resource-list-item-delete">
+      <button
+        className="resource-list-item-delete"
+        onClick={onClickDelete}
+        disabled={isDeleting}>
         Delete
       </button>
     </li>

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -4,12 +4,12 @@ export default function CategoryListItem({category}) {
   return (
     <li className="resource-list-item category-list-item">
       <span className="category-list-item-emoji">
-        🤔
+        {category.emoji}
       </span>
       <span className="category-list-item-label">
         {category.label}
       </span>
-      <button className="delete-category">
+      <button className="resource-list-item-delete">
         Delete
       </button>
     </li>

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function CategoryListItem({category}) {
+  return (
+    <li className="resource-list-item category-list-item">
+      <span className="category-list-item-emoji">
+        🤔
+      </span>
+      <span className="category-list-item-label">
+        {category.label}
+      </span>
+      <button className="delete-category">
+        Delete
+      </button>
+    </li>
+  );
+}

--- a/client-src/categories/components/content/index.js
+++ b/client-src/categories/components/content/index.js
@@ -15,7 +15,8 @@ export const Categories = React.createClass({
   render() {
     const {
       retrievingCategories, categories,
-      categoriesActions, currentlyDeleting
+      categoriesActions, currentlyDeleting,
+      isOnline
     } = this.props;
 
     if (retrievingCategories) {
@@ -27,14 +28,16 @@ export const Categories = React.createClass({
     }
 
     return (<CategoriesList
-        categories={categories}
-        categoriesActions={categoriesActions}
-        currentlyDeleting={currentlyDeleting}/>);
+      isOnline={isOnline}
+      categories={categories}
+      categoriesActions={categoriesActions}
+      currentlyDeleting={currentlyDeleting}/>);
   }
 });
 
 function mapStateToProps(state) {
   return {
+    isOnline: state.connection,
     categories: state.categories.categories,
     currentlyDeleting: state.categories.currentlyDeleting,
     retrievingCategories: state.categories.retrievingCategories

--- a/client-src/categories/components/content/index.js
+++ b/client-src/categories/components/content/index.js
@@ -1,9 +1,33 @@
 import React from 'react';
+import {bindActionCreators} from 'redux';
+import {connect} from 'react-redux';
+import * as categoriesActionCreators from '../../../redux/categories/action-creators';
 
-export default function Categories() {
-  return (
-    <div className="categories-content">
-      Categories is here
-    </div>
-  );
+export const Categories = React.createClass({
+  componentDidMount() {
+    const {categoriesActions} = this.props;
+    categoriesActions.retrieveCategories();
+  },
+
+  render() {
+    return (
+      <div className="categories-content">
+        Categories is here
+      </div>
+    );
+  }
+});
+
+function mapStateToProps(state) {
+  return {
+    categories: state.categories.categories
+  };
 }
+
+function mapDispatchToProps(dispatch) {
+  return {
+    categoriesActions: bindActionCreators(categoriesActionCreators, dispatch)
+  };
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(Categories);

--- a/client-src/categories/components/content/index.js
+++ b/client-src/categories/components/content/index.js
@@ -2,7 +2,6 @@ import React from 'react';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import * as categoriesActionCreators from '../../../redux/categories/action-creators';
-import * as alertActionCreators from '../../../redux/alert/action-creators';
 import CategoriesList from '../categories-list';
 import LoadingCategories from '../loading-categories';
 import EmptyCategories from '../empty-categories';
@@ -16,8 +15,7 @@ export const Categories = React.createClass({
   render() {
     const {
       retrievingCategories, categories,
-      categoriesActions, alertActions,
-      currentlyDeleting, isOnline
+      categoriesActions, currentlyDeleting, isOnline
     } = this.props;
 
     if (retrievingCategories) {
@@ -31,7 +29,6 @@ export const Categories = React.createClass({
     return (<CategoriesList
       isOnline={isOnline}
       categories={categories}
-      alertActions={alertActions}
       categoriesActions={categoriesActions}
       currentlyDeleting={currentlyDeleting}/>);
   }
@@ -48,7 +45,6 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    alertActions: bindActionCreators(alertActionCreators, dispatch),
     categoriesActions: bindActionCreators(categoriesActionCreators, dispatch)
   };
 }

--- a/client-src/categories/components/content/index.js
+++ b/client-src/categories/components/content/index.js
@@ -2,6 +2,9 @@ import React from 'react';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import * as categoriesActionCreators from '../../../redux/categories/action-creators';
+import CategoriesList from '../categories-list';
+import LoadingCategories from '../loading-categories';
+import EmptyCategories from '../empty-categories';
 
 export const Categories = React.createClass({
   componentDidMount() {
@@ -10,17 +13,22 @@ export const Categories = React.createClass({
   },
 
   render() {
-    return (
-      <div className="categories-content">
-        Categories is here
-      </div>
-    );
+    if (this.props.retrievingCategories) {
+      return <LoadingCategories/>;
+    }
+
+    if (!this.props.categories.length) {
+      return <EmptyCategories/>;
+    }
+
+    return (<CategoriesList categories={this.props.categories}/>);
   }
 });
 
 function mapStateToProps(state) {
   return {
-    categories: state.categories.categories
+    categories: state.categories.categories,
+    retrievingCategories: state.categories.retrievingCategories
   };
 }
 

--- a/client-src/categories/components/content/index.js
+++ b/client-src/categories/components/content/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import {bindActionCreators} from 'redux';
 import {connect} from 'react-redux';
 import * as categoriesActionCreators from '../../../redux/categories/action-creators';
+import * as alertActionCreators from '../../../redux/alert/action-creators';
 import CategoriesList from '../categories-list';
 import LoadingCategories from '../loading-categories';
 import EmptyCategories from '../empty-categories';
@@ -15,8 +16,8 @@ export const Categories = React.createClass({
   render() {
     const {
       retrievingCategories, categories,
-      categoriesActions, currentlyDeleting,
-      isOnline
+      categoriesActions, alertActions,
+      currentlyDeleting, isOnline
     } = this.props;
 
     if (retrievingCategories) {
@@ -30,6 +31,7 @@ export const Categories = React.createClass({
     return (<CategoriesList
       isOnline={isOnline}
       categories={categories}
+      alertActions={alertActions}
       categoriesActions={categoriesActions}
       currentlyDeleting={currentlyDeleting}/>);
   }
@@ -46,6 +48,7 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
+    alertActions: bindActionCreators(alertActionCreators, dispatch),
     categoriesActions: bindActionCreators(categoriesActionCreators, dispatch)
   };
 }

--- a/client-src/categories/components/content/index.js
+++ b/client-src/categories/components/content/index.js
@@ -13,21 +13,30 @@ export const Categories = React.createClass({
   },
 
   render() {
-    if (this.props.retrievingCategories) {
+    const {
+      retrievingCategories, categories,
+      categoriesActions, currentlyDeleting
+    } = this.props;
+
+    if (retrievingCategories) {
       return <LoadingCategories/>;
     }
 
-    if (!this.props.categories.length) {
+    if (!categories.length) {
       return <EmptyCategories/>;
     }
 
-    return (<CategoriesList categories={this.props.categories}/>);
+    return (<CategoriesList
+        categories={categories}
+        categoriesActions={categoriesActions}
+        currentlyDeleting={currentlyDeleting}/>);
   }
 });
 
 function mapStateToProps(state) {
   return {
     categories: state.categories.categories,
+    currentlyDeleting: state.categories.currentlyDeleting,
     retrievingCategories: state.categories.retrievingCategories
   };
 }

--- a/client-src/categories/components/empty-categories/index.js
+++ b/client-src/categories/components/empty-categories/index.js
@@ -4,10 +4,11 @@ export default function EmptyCategories() {
   return (
     <div className="empty-resource-list">
       <div className="empty-resource-list-message">
-        Categories will appear here.
+        There are no categories.
       </div>
       <div className="empty-resource-list-explanation">
-        Related transactions can be grouped together using categories.
+        This page will list categories that you create. Related transactions
+        can be grouped together using categories.
       </div>
     </div>
   );

--- a/client-src/categories/components/empty-categories/index.js
+++ b/client-src/categories/components/empty-categories/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function EmptyCategories() {
+  return (
+    <div className="empty-categories">
+      There are no categories to display.
+    </div>
+  );
+}

--- a/client-src/categories/components/empty-categories/index.js
+++ b/client-src/categories/components/empty-categories/index.js
@@ -2,8 +2,13 @@ import React from 'react';
 
 export default function EmptyCategories() {
   return (
-    <div className="empty-categories">
-      There are no categories to display.
+    <div className="empty-resource-list">
+      <div className="empty-resource-list-message">
+        Categories will appear here.
+      </div>
+      <div className="empty-resource-list-explanation">
+        Related transactions can be grouped together using categories.
+      </div>
     </div>
   );
 }

--- a/client-src/categories/components/loading-categories/index.js
+++ b/client-src/categories/components/loading-categories/index.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function LoadingCategories() {
+  return (
+    <div className="loading-categories">
+      Loading categories...
+    </div>
+  );
+}

--- a/client-src/categories/components/loading-categories/index.js
+++ b/client-src/categories/components/loading-categories/index.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import LoadingIndicator from '../../../common/components/loading-indicator';
 
 export default function LoadingCategories() {
   return (
-    <div className="loading-categories">
-      Loading categories...
+    <div className="loading-resource-list">
+      <LoadingIndicator/>
     </div>
   );
 }

--- a/client-src/categories/components/subheader/index.js
+++ b/client-src/categories/components/subheader/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import {connect} from 'react-redux';
 
-export default function CategoriesSubheader() {
+export function CategoriesSubheader({isOnline}) {
   function onClickNew() {
     console.log('clicked');
   }
 
-  const disabled = false;
+  const disabled = !isOnline;
 
   return (
     <div className="sub-header">
@@ -23,3 +24,11 @@ export default function CategoriesSubheader() {
     </div>
   );
 }
+
+function mapStateToProps(state) {
+  return {
+    isOnline: state.connection
+  };
+}
+
+export default connect(mapStateToProps)(CategoriesSubheader);

--- a/client-src/categories/components/subheader/index.js
+++ b/client-src/categories/components/subheader/index.js
@@ -14,7 +14,7 @@ export default function CategoriesSubheader() {
           Categories
         </h1>
         <button
-          className="subheader-action btn btn-line"
+          className="subheader-action btn"
           onClick={onClickNew}
           disabled={disabled}>
           + Category

--- a/client-src/common/components/alert/alert.styl
+++ b/client-src/common/components/alert/alert.styl
@@ -1,15 +1,16 @@
 .alert
-  display none
   position fixed
   top 46px
   left 0
-  height 48px
+  height 0
+  overflow hidden
   width 100%
   padding 0 15px
   line-height 48px
   text-align center
   color #fff
   z-index 100
+  transition height 0.25s
 
   &.warning
     background radial-gradient(circle at top right, #ffa648, #ff7f1b)
@@ -20,9 +21,13 @@
   &.success
     background radial-gradient(circle at top right, #a6d659, #37b645)
 
+  &.info
+    background radial-gradient(circle at top right, #36c7f4, #6593f0)
+
+  // When this becomes visible, the `content-container` scoots down to make
+  // room. This behavior is specified in `scaffolding.styl`
   &.visible
-    display block
-    opacity 1
+    height 48px
 
   .alert-icon
-    margin-right 3px
+    margin-right 7px

--- a/client-src/common/components/alert/alert.styl
+++ b/client-src/common/components/alert/alert.styl
@@ -5,11 +5,12 @@
   height 0
   overflow hidden
   width 100%
-  padding 0 15px
   line-height 48px
   text-align center
   color #fff
   z-index 100
+  display flex
+  align-items center
   transition height 0.25s
 
   &.warning
@@ -29,5 +30,14 @@
   &.visible
     height 48px
 
+  .alert-text
+    flex 1
+    // The left padding is so large to account for the space taken up
+    // by the `dismiss` icon.
+    padding 0 15px 0 37px
+
   .alert-icon
     margin-right 7px
+
+  .alert-dismiss
+    margin 0 15px 0 auto

--- a/client-src/common/components/alert/index.js
+++ b/client-src/common/components/alert/index.js
@@ -1,26 +1,43 @@
 import React from 'react';
 import classNames from 'classnames';
-import {connect} from 'react-redux';
 
-export function Alert({connection}) {
+// Each style of alert has a default icon. This maps an
+// alert style to the class name representing that icon
+const defaultIconMap = {
+  success: 'zmdi-check',
+  info: 'zmdi-info-outline',
+  warning: 'zmdi-alert-triangle',
+  danger: 'zmdi-alert-circle-o',
+};
+
+export default function Alert(props) {
+  const {
+    visible,
+    style,
+    icon,
+    text
+  } = props;
+
   const alertClass = classNames({
     alert: true,
-    warning: true,
-    visible: !connection
+    [style]: true,
+    visible: visible
+  });
+
+  // If the user has passed an `icon`, then we use that value
+  // for the class of the icon. Otherwise, we use the default value.
+  const materialIconClass = icon ? icon : defaultIconMap[style];
+
+  const iconClass = classNames({
+    zmdi: true,
+    'alert-icon': true,
+    [materialIconClass]: true
   });
 
   return (
     <div className={alertClass}>
-      <i className="zmdi zmdi-alert-triangle alert-icon"></i>
-      You seem to have lost connection.
+      <i className={iconClass}></i>
+      {text}
     </div>
   );
 }
-
-function mapStateToProps(state) {
-  return {
-    connection: state.connection
-  };
-}
-
-export default connect(mapStateToProps)(Alert);

--- a/client-src/common/components/alert/index.js
+++ b/client-src/common/components/alert/index.js
@@ -18,6 +18,10 @@ export default function Alert(props) {
     text
   } = props;
 
+  if (!visible) {
+    return null;
+  }
+
   const alertClass = classNames({
     alert: true,
     [style]: true,

--- a/client-src/common/components/alert/index.js
+++ b/client-src/common/components/alert/index.js
@@ -17,7 +17,8 @@ export default function Alert(props) {
     icon,
     text,
     undoCallback,
-    isDismissable
+    isDismissable,
+    dismissCurrentAlert
   } = props;
 
   const alertClass = classNames({
@@ -47,8 +48,15 @@ export default function Alert(props) {
 
   let dismissIcon;
   if (isDismissable) {
+    // If the modal is being hidden, then we can't dismiss it
+    const dismissDisabled = !visible;
     dismissIcon = (
-      <i className="zmdi zmdi-close alert-dismiss"/>
+      <button
+        className="alert-dismiss"
+        disabled={dismissDisabled}
+        onClick={() => dismissCurrentAlert()}>
+        <i className="zmdi zmdi-close"/>
+      </button>
     );
   }
 

--- a/client-src/common/components/alert/index.js
+++ b/client-src/common/components/alert/index.js
@@ -48,15 +48,17 @@ export default function Alert(props) {
   let dismissIcon;
   if (isDismissable) {
     dismissIcon = (
-      <i className="zmdi zmdi-close"/>
+      <i className="zmdi zmdi-close alert-dismiss"/>
     );
   }
 
   return (
     <div className={alertClass}>
-      <i className={iconClass}></i>
-      {text}
-      {undoText}
+      <span className="alert-text">
+        <i className={iconClass}></i>
+        {text}
+        {undoText}
+      </span>
       {dismissIcon}
     </div>
   );

--- a/client-src/common/components/alert/index.js
+++ b/client-src/common/components/alert/index.js
@@ -15,17 +15,15 @@ export default function Alert(props) {
     visible,
     style,
     icon,
-    text
+    text,
+    undoCallback,
+    isDismissable
   } = props;
-
-  if (!visible) {
-    return null;
-  }
 
   const alertClass = classNames({
     alert: true,
     [style]: true,
-    visible: visible
+    visible
   });
 
   // If the user has passed an `icon`, then we use that value
@@ -38,10 +36,28 @@ export default function Alert(props) {
     [materialIconClass]: true
   });
 
+  let undoText;
+  if (undoCallback) {
+    undoText = (
+      <button className="alert-undo" onClick={undoCallback}>
+        Undo
+      </button>
+    );
+  }
+
+  let dismissIcon;
+  if (isDismissable) {
+    dismissIcon = (
+      <i className="zmdi zmdi-close"/>
+    );
+  }
+
   return (
     <div className={alertClass}>
       <i className={iconClass}></i>
       {text}
+      {undoText}
+      {dismissIcon}
     </div>
   );
 }

--- a/client-src/common/components/header/header.styl
+++ b/client-src/common/components/header/header.styl
@@ -3,7 +3,6 @@ header
   top 0
   right 0
   left 0
-  min-width 320px
   height 46px
   padding 0 10px
   background-color #fafafa
@@ -30,14 +29,17 @@ header
     font-weight bold
 
     a
-      font-size 21px
       primary-gradient-fill()
+      clip-bg-to-text()
+      font-size 21px
+
 
     +respond-from($m-screen-min)
       display block
 
   .mobile-menu-toggle
     primary-gradient-fill()
+    clip-bg-to-text()
 
     +respond-from($m-screen-min)
       display none
@@ -68,6 +70,8 @@ header
     align-items center
 
   .header-name
+    ellipsis()
+    max-width 150px
     margin-right 10px
 
   .header-profile-pic

--- a/client-src/common/components/header/header.styl
+++ b/client-src/common/components/header/header.styl
@@ -3,6 +3,7 @@ header
   top 0
   right 0
   left 0
+  z-index 1000
   height 46px
   padding 0 10px
   background-color #fafafa

--- a/client-src/common/components/layout/index.js
+++ b/client-src/common/components/layout/index.js
@@ -1,14 +1,23 @@
 import React from 'react';
+import {connect} from 'react-redux';
 import Header from '../header';
 import Footer from '../footer';
 import Alert from '../alert';
 import MobileNav from '../mobile-nav';
 
-export default function Layout({main, subheader}) {
+export function Layout(props) {
+  const {
+    main,
+    subheader,
+    showAlert,
+    alertStyle,
+    alertText
+  } = props;
+
   const alertProps = {
-    visible: true,
-    style: 'info',
-    text: 'An update was installed'
+    visible: showAlert,
+    style: alertStyle,
+    text: alertText
   };
 
   return (
@@ -26,3 +35,13 @@ export default function Layout({main, subheader}) {
     </div>
   );
 }
+
+function mapStateToProps(state) {
+  return {
+    showAlert: state.ui.showAlert,
+    alertStyle: state.ui.alertStyle,
+    alertText: state.ui.alertText
+  };
+}
+
+export default connect(mapStateToProps, null, null, {pure: false})(Layout);

--- a/client-src/common/components/layout/index.js
+++ b/client-src/common/components/layout/index.js
@@ -53,14 +53,20 @@ const Layout = React.createClass({
     const {
       main,
       subheader,
-      alertProps
+      alertProps,
+      alertActions
     } = this.props;
+
+    const allAlertProps = {
+      ...alertProps,
+      ...alertActions
+    };
 
     return (
       <div>
         <Header/>
         <MobileNav/>
-        <Alert {...alertProps}/>
+        <Alert {...allAlertProps}/>
         <div className="content-container">
           {subheader}
           <main>

--- a/client-src/common/components/layout/index.js
+++ b/client-src/common/components/layout/index.js
@@ -9,26 +9,44 @@ import * as alertActionCreators from '../../../redux/alert/action-creators';
 import * as connectionActionCreators from '../../../redux/connection/action-creators';
 
 const Layout = React.createClass({
-  componentDidMount() {
+  // When the user goes offline, we update the connection status
+  // and show an alert
+  onOffline() {
     const {
       alertActions,
       connectionActions
     } = this.props;
 
-    window.addEventListener('offline', () => {
-      connectionActions.userOffline();
-      alertActions.queueAlert({
-        style: 'warning',
-        text: 'You are not connected to the internet',
-        persistent: true,
-        isDismissable: false
-      });
+    connectionActions.userOffline();
+    alertActions.queueAlert({
+      style: 'warning',
+      text: 'You are not connected to the internet',
+      persistent: true,
+      isDismissable: false
     });
+  },
 
-    window.addEventListener('online', () => {
-      connectionActions.userOnline();
-      alertActions.dismissCurrentAlert();
-    });
+  // When the user comes back online, we update the connection
+  // status and dismiss the alert
+  onOnline() {
+    const {
+      alertActions,
+      connectionActions
+    } = this.props;
+
+    connectionActions.userOnline();
+    alertActions.dismissCurrentAlert();
+  },
+
+  componentDidMount() {
+    // This handles the user being offline at the
+    // time of the app launching
+    if (!window.navigator.onLine) {
+      this.onOffline();
+    }
+
+    window.addEventListener('offline', this.onOffline);
+    window.addEventListener('online', this.onOnline);
   },
 
   render() {

--- a/client-src/common/components/layout/index.js
+++ b/client-src/common/components/layout/index.js
@@ -13,9 +13,7 @@ export default function Layout({main, subheader}) {
       <div className="content-container">
         {subheader}
         <main>
-          <div className="container">
-            {main}
-          </div>
+          {main}
         </main>
         <Footer/>
       </div>

--- a/client-src/common/components/layout/index.js
+++ b/client-src/common/components/layout/index.js
@@ -5,11 +5,17 @@ import Alert from '../alert';
 import MobileNav from '../mobile-nav';
 
 export default function Layout({main, subheader}) {
+  const alertProps = {
+    visible: true,
+    style: 'info',
+    text: 'An update was installed'
+  };
+
   return (
     <div>
       <Header/>
       <MobileNav/>
-      <Alert/>
+      <Alert {...alertProps}/>
       <div className="content-container">
         {subheader}
         <main>

--- a/client-src/common/components/loading-indicator/index.js
+++ b/client-src/common/components/loading-indicator/index.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export default function LoadingIndicator() {
+  // HTML generated from SpinKit
+  // http://tobiasahlin.com/spinkit/
+  return (
+    <div className="sk-fading-circle">
+      <div className="sk-circle1 sk-circle"></div>
+      <div className="sk-circle2 sk-circle"></div>
+      <div className="sk-circle3 sk-circle"></div>
+      <div className="sk-circle4 sk-circle"></div>
+      <div className="sk-circle5 sk-circle"></div>
+      <div className="sk-circle6 sk-circle"></div>
+      <div className="sk-circle7 sk-circle"></div>
+      <div className="sk-circle8 sk-circle"></div>
+      <div className="sk-circle9 sk-circle"></div>
+      <div className="sk-circle10 sk-circle"></div>
+      <div className="sk-circle11 sk-circle"></div>
+      <div className="sk-circle12 sk-circle"></div>
+    </div>
+  );
+}

--- a/client-src/common/components/loading-indicator/loading-indicator.styl
+++ b/client-src/common/components/loading-indicator/loading-indicator.styl
@@ -1,0 +1,136 @@
+// CSS generated from SpinKit
+// http://tobiasahlin.com/spinkit/
+.sk-fading-circle {
+  width: 40px;
+  height: 40px;
+  position: relative;
+}
+
+.sk-fading-circle .sk-circle {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  left: 0;
+  top: 0;
+}
+
+.sk-fading-circle .sk-circle:before {
+  content: '';
+  display: block;
+  margin: 0 auto;
+  width: 15%;
+  height: 15%;
+  background-color: #aaa;
+  border-radius: 100%;
+  -webkit-animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
+          animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
+}
+.sk-fading-circle .sk-circle2 {
+  -webkit-transform: rotate(30deg);
+      -ms-transform: rotate(30deg);
+          transform: rotate(30deg);
+}
+.sk-fading-circle .sk-circle3 {
+  -webkit-transform: rotate(60deg);
+      -ms-transform: rotate(60deg);
+          transform: rotate(60deg);
+}
+.sk-fading-circle .sk-circle4 {
+  -webkit-transform: rotate(90deg);
+      -ms-transform: rotate(90deg);
+          transform: rotate(90deg);
+}
+.sk-fading-circle .sk-circle5 {
+  -webkit-transform: rotate(120deg);
+      -ms-transform: rotate(120deg);
+          transform: rotate(120deg);
+}
+.sk-fading-circle .sk-circle6 {
+  -webkit-transform: rotate(150deg);
+      -ms-transform: rotate(150deg);
+          transform: rotate(150deg);
+}
+.sk-fading-circle .sk-circle7 {
+  -webkit-transform: rotate(180deg);
+      -ms-transform: rotate(180deg);
+          transform: rotate(180deg);
+}
+.sk-fading-circle .sk-circle8 {
+  -webkit-transform: rotate(210deg);
+      -ms-transform: rotate(210deg);
+          transform: rotate(210deg);
+}
+.sk-fading-circle .sk-circle9 {
+  -webkit-transform: rotate(240deg);
+      -ms-transform: rotate(240deg);
+          transform: rotate(240deg);
+}
+.sk-fading-circle .sk-circle10 {
+  -webkit-transform: rotate(270deg);
+      -ms-transform: rotate(270deg);
+          transform: rotate(270deg);
+}
+.sk-fading-circle .sk-circle11 {
+  -webkit-transform: rotate(300deg);
+      -ms-transform: rotate(300deg);
+          transform: rotate(300deg);
+}
+.sk-fading-circle .sk-circle12 {
+  -webkit-transform: rotate(330deg);
+      -ms-transform: rotate(330deg);
+          transform: rotate(330deg);
+}
+.sk-fading-circle .sk-circle2:before {
+  -webkit-animation-delay: -1.1s;
+          animation-delay: -1.1s;
+}
+.sk-fading-circle .sk-circle3:before {
+  -webkit-animation-delay: -1s;
+          animation-delay: -1s;
+}
+.sk-fading-circle .sk-circle4:before {
+  -webkit-animation-delay: -0.9s;
+          animation-delay: -0.9s;
+}
+.sk-fading-circle .sk-circle5:before {
+  -webkit-animation-delay: -0.8s;
+          animation-delay: -0.8s;
+}
+.sk-fading-circle .sk-circle6:before {
+  -webkit-animation-delay: -0.7s;
+          animation-delay: -0.7s;
+}
+.sk-fading-circle .sk-circle7:before {
+  -webkit-animation-delay: -0.6s;
+          animation-delay: -0.6s;
+}
+.sk-fading-circle .sk-circle8:before {
+  -webkit-animation-delay: -0.5s;
+          animation-delay: -0.5s;
+}
+.sk-fading-circle .sk-circle9:before {
+  -webkit-animation-delay: -0.4s;
+          animation-delay: -0.4s;
+}
+.sk-fading-circle .sk-circle10:before {
+  -webkit-animation-delay: -0.3s;
+          animation-delay: -0.3s;
+}
+.sk-fading-circle .sk-circle11:before {
+  -webkit-animation-delay: -0.2s;
+          animation-delay: -0.2s;
+}
+.sk-fading-circle .sk-circle12:before {
+  -webkit-animation-delay: -0.1s;
+          animation-delay: -0.1s;
+}
+
+@-webkit-keyframes sk-circleFadeDelay {
+  0%, 39%, 100% { opacity: 0; }
+  40% { opacity: 1; }
+}
+
+@keyframes sk-circleFadeDelay {
+  0%, 39%, 100% { opacity: 0; }
+  40% { opacity: 1; }
+}

--- a/client-src/common/components/stylus/empty-resource-list.styl
+++ b/client-src/common/components/stylus/empty-resource-list.styl
@@ -1,0 +1,12 @@
+.empty-resource-list
+  padding 0 30px
+  margin-top 36px
+  text-align center
+
+  .empty-resource-list-message
+    color #999
+    font-size 17px
+    margin-bottom 10px
+
+  .empty-resource-list-explanation
+    color #aaa

--- a/client-src/common/components/stylus/loading-resource-list.styl
+++ b/client-src/common/components/stylus/loading-resource-list.styl
@@ -1,0 +1,4 @@
+.loading-resource-list
+  margin-top 36px
+  display flex
+  justify-content center

--- a/client-src/common/components/stylus/resource-list.styl
+++ b/client-src/common/components/stylus/resource-list.styl
@@ -16,6 +16,7 @@
     margin 0 15px 0 auto
     width 50px
     flex 0
+    transition color 0.25s
 
     &[disabled]
       color #dfdfdf

--- a/client-src/common/components/stylus/resource-list.styl
+++ b/client-src/common/components/stylus/resource-list.styl
@@ -17,6 +17,9 @@
     width 50px
     flex 0
 
+    &[disabled]
+      color #dfdfdf
+
 // Resource list items have a top border. The subheader has a bottom border.
 // This rule makes it so that when the subheader and resource list are
 // visually next to one another, their borders overlap so as not to produce

--- a/client-src/common/components/stylus/resource-list.styl
+++ b/client-src/common/components/stylus/resource-list.styl
@@ -1,0 +1,10 @@
+.resource-list
+  margin 0
+  padding 0
+
+  .resource-list-item
+    padding 0
+    border-bottom 1px solid #eee
+
+    &:first-child
+      border-top 1px solid #eee

--- a/client-src/common/components/stylus/resource-list.styl
+++ b/client-src/common/components/stylus/resource-list.styl
@@ -8,3 +8,18 @@
 
     &:first-child
       border-top 1px solid #eee
+
+  .resource-list-item-delete
+    font-size 15px
+    color #b5b5b5
+    cursor pointer
+    margin 0 15px 0 auto
+    width 50px
+    flex 0
+
+// Resource list items have a top border. The subheader has a bottom border.
+// This rule makes it so that when the subheader and resource list are
+// visually next to one another, their borders overlap so as not to produce
+// a double-border effect.
+main > .resource-list:first-child
+  margin-top -1px

--- a/client-src/common/stylus/buttons.styl
+++ b/client-src/common/stylus/buttons.styl
@@ -14,6 +14,11 @@
   border-radius 6px
   padding 0 13px
   color #fff
+  opacity 1
+  transition opacity 0.25s
+
+  &[disabled]
+    opacity 0.35
 
   &.btn-line
     color #C7236C

--- a/client-src/common/stylus/buttons.styl
+++ b/client-src/common/stylus/buttons.styl
@@ -1,4 +1,5 @@
 .btn
+  primary-gradient-fill()
   display inline-block
   font-size 15px
   font-weight 500
@@ -9,17 +10,10 @@
   vertical-align middle
   cursor pointer
   user-select none
-  border 1px solid #c3c3c3
+  border 0
   border-radius 6px
   padding 0 13px
-  color #888
-  background-color #f3f3f3
-
-  &:hover
-    background-color #ebebeb
-
-  &:active
-    background-color #dfdfdf
+  color #fff
 
   &.btn-line
     color #C7236C

--- a/client-src/common/stylus/reset.styl
+++ b/client-src/common/stylus/reset.styl
@@ -6,3 +6,23 @@ ul
 button
   background transparent
   border none
+
+// Resets the cursor
+html,
+body
+	cursor default
+
+code
+	cursor text
+
+a,
+label,
+button, 
+input[type="radio"],
+input[type="submit"],
+input[type="checkbox"]
+	cursor pointer
+
+button[disabled],
+input[disabled]
+	cursor default

--- a/client-src/common/stylus/scaffolding.styl
+++ b/client-src/common/stylus/scaffolding.styl
@@ -25,5 +25,5 @@ body
   min-height: calc(100vh - 46px);
 
 main
-  padding 15px 0 20px
+  margin-bottom 36px
   flex 1

--- a/client-src/common/stylus/scaffolding.styl
+++ b/client-src/common/stylus/scaffolding.styl
@@ -22,7 +22,14 @@ body
   display flex
   flex-direction column
   // 45px for the fixed position header
-  min-height: calc(100vh - 46px);
+  min-height calc(100vh - 46px)
+  padding-top 0
+  transition padding 0.25s
+
+// When the alert is visible, we scoot down the content container
+// so that they don't overlap with one another.
+.alert.visible + .content-container
+  padding-top 48px
 
 main
   margin-bottom 36px

--- a/client-src/common/stylus/typography.styl
+++ b/client-src/common/stylus/typography.styl
@@ -17,7 +17,7 @@ h1, h2, h3, h4, h5, h6
   font-weight normal
 
 .lots-of-text
-  contentPadding()
+  content-padding()
   color #666
   line-height 1.8
 

--- a/client-src/common/stylus/typography.styl
+++ b/client-src/common/stylus/typography.styl
@@ -17,6 +17,7 @@ h1, h2, h3, h4, h5, h6
   font-weight normal
 
 .lots-of-text
+  contentPadding()
   color #666
   line-height 1.8
 

--- a/client-src/mixins.styl
+++ b/client-src/mixins.styl
@@ -3,7 +3,7 @@ ellipsis()
   white-space no-wrap
   text-overflow ellipsis
 
-contentPadding()
+content-padding()
   padding 0 15px
 
 primary-gradient-fill()

--- a/client-src/mixins.styl
+++ b/client-src/mixins.styl
@@ -3,9 +3,14 @@ ellipsis()
   white-space no-wrap
   text-overflow ellipsis
 
+contentPadding()
+  padding 0 15px
+
 primary-gradient-fill()
   color #c7236c
   background radial-gradient(circle at top right, #f5582e, #8000d4)
+
+clip-bg-to-text()
   -webkit-background-clip text
   -webkit-text-fill-color transparent
 

--- a/client-src/redux/alert/action-creators.js
+++ b/client-src/redux/alert/action-creators.js
@@ -1,0 +1,29 @@
+import _ from 'lodash';
+import actionTypes from './action-types';
+
+// Queues an alert to be displayed
+export function queueAlert(alertDescription) {
+  return dispatch => {
+    const alertId = _.uniqueId('alert-');
+    dispatch({
+      type: actionTypes.QUEUE_ALERT,
+      ...alertDescription,
+      alertId
+    });
+
+    // Alerts display for 2 seconds unless `persistent` is passed.
+    if (!alertDescription.persistent) {
+      window.setTimeout(() => dispatch({
+        type: actionTypes.DISMISS_ALERT_BY_ID,
+        alertId
+      }), 2000);
+    }
+  };
+}
+
+// Dismisses the current alert, showing the queued one, if it exists
+export function dismissCurrentAlert() {
+  return {
+    type: actionTypes.DISMISS_CURRENT_ALERT
+  };
+}

--- a/client-src/redux/alert/action-types.js
+++ b/client-src/redux/alert/action-types.js
@@ -1,0 +1,7 @@
+import keyMirror from 'keymirror';
+
+export default keyMirror({
+  QUEUE_ALERT: null,
+  DISMISS_ALERT_BY_ID: null,
+  DISMISS_CURRENT_ALERT: null
+});

--- a/client-src/redux/alert/initial-state.js
+++ b/client-src/redux/alert/initial-state.js
@@ -1,0 +1,7 @@
+export default {
+  visible: false,
+  isDismissable: null,
+  text: '',
+  style: '',
+  icon: ''
+};

--- a/client-src/redux/alert/reducer.js
+++ b/client-src/redux/alert/reducer.js
@@ -27,7 +27,6 @@ export default (state = initialState, action) => {
       else {
         return {
           ...state,
-          isDismissable: null,
           alertId: null,
           visible: false
         };
@@ -40,7 +39,6 @@ export default (state = initialState, action) => {
     case actionTypes.DISMISS_CURRENT_ALERT: {
       return {
         ...state,
-        isDismissable: null,
         alertId: null,
         visible: false
       };

--- a/client-src/redux/alert/reducer.js
+++ b/client-src/redux/alert/reducer.js
@@ -1,0 +1,52 @@
+import _ from 'lodash';
+import actionTypes from './action-types';
+import initialState from './initial-state';
+
+const validActionProps = [
+  'text', 'style', 'isDismissable',
+  'icon', 'alertId'
+];
+
+export default (state = initialState, action) => {
+  const strippedAction = _.pick(action, validActionProps);
+  switch (action.type) {
+    case actionTypes.QUEUE_ALERT: {
+      return {
+        ...state,
+        ...strippedAction,
+        visible: true
+      };
+    }
+
+    case actionTypes.DISMISS_ALERT_BY_ID: {
+      // If the current alert doesn't match, then we do nothing
+      if (state.alertId !== action.alertId) {
+        return state;
+      }
+      // Otherwise, we hide the alert
+      else {
+        return {
+          ...state,
+          isDismissable: null,
+          alertId: null,
+          visible: false
+        };
+      }
+    }
+
+    // All that dismissing the current alert does is make the
+    // alert hidden. It keeps the other info so that it animates
+    // out properly.
+    case actionTypes.DISMISS_CURRENT_ALERT: {
+      return {
+        ...state,
+        isDismissable: null,
+        alertId: null,
+        visible: false
+      };
+    }
+    default: {
+      return state;
+    }
+  }
+};

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -1,4 +1,5 @@
 import actionTypes from './action-types';
+import * as alertActionCreators from '../alert/action-creators';
 import mockCategories from '../mock/categories';
 
 let categoriesLength = mockCategories.length;
@@ -59,6 +60,16 @@ export function deleteCategory(categoryId) {
     dispatch({type: actionTypes.DELETE_CATEGORY, categoryId});
 
     window.setTimeout(() => {
+      dispatch(alertActionCreators.queueAlert({
+        text: 'Category deleted',
+        style: 'success',
+        isDismissable: true,
+        persistent: false,
+        undoCallback() {
+          console.log('A request has been made to undo a Category delete.');
+        }
+      }));
+
       dispatch({
         type: actionTypes.DELETE_CATEGORY_SUCCESS,
         categoryId

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -34,7 +34,7 @@ export function retrieveCategories() {
     window.setTimeout(() => {
       dispatch({
         type: actionTypes.RETRIEVE_CATEGORIES_SUCCESS,
-        categories: []
+        categories: [...mockCategories]
       });
     }, 1200);
   };

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -34,13 +34,13 @@ export function retrieveCategories() {
     window.setTimeout(() => {
       dispatch({
         type: actionTypes.RETRIEVE_CATEGORIES_SUCCESS,
-        categories: [...mockCategories]
+        categories: []
       });
     }, 1200);
   };
 }
 
-export function updateCategory(categoryId, data) {
+export function updateCategory(categoryId) {
   return dispatch => {
     dispatch({type: actionTypes.UPDATE_CATEGORY, categoryId});
 

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -44,26 +44,13 @@ export function updateCategory(categoryId, data) {
   return dispatch => {
     dispatch({type: actionTypes.UPDATE_CATEGORY, categoryId});
 
-    fetch(`/api/v1/categories/${categoryId}`, {
-      method: 'PATCH',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(data)
-    })
-      .then(resp => resp.json())
-      .then(resp => {
-        dispatch({
-          type: actionTypes.UPDATE_CATEGORY_SUCCESS,
-          categoryId,
-          category: resp.data
-        });
-      })
-      .catch(() => dispatch({
-        type: actionTypes.UPDATE_CATEGORY_FAILURE,
+    window.setTimeout(() => {
+      // This needs to send the updated category
+      dispatch({
+        type: actionTypes.UPDATE_CATEGORY_SUCCESS,
         categoryId
-      }));
+      });
+    }, 1000);
   };
 }
 
@@ -71,16 +58,11 @@ export function deleteCategory(categoryId) {
   return dispatch => {
     dispatch({type: actionTypes.DELETE_CATEGORY, categoryId});
 
-    fetch(`/api/v1/categories/${categoryId}`, {method: 'DELETE'})
-      .then(() => {
-        dispatch({
-          type: actionTypes.DELETE_CATEGORY_SUCCESS,
-          categoryId
-        });
-      })
-      .catch(() => dispatch({
-        type: actionTypes.DELETE_CATEGORY_FAILURE,
+    window.setTimeout(() => {
+      dispatch({
+        type: actionTypes.DELETE_CATEGORY_SUCCESS,
         categoryId
-      }));
+      });
+    }, 1000);
   };
 }

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -1,27 +1,45 @@
 import actionTypes from './action-types';
 
+const mockCategories = [
+  {
+    id: 1,
+    label: 'Food',
+    emoji: 'apple'
+  },
+  {
+    id: 2,
+    label: 'Childcare',
+    emoji: null
+  },
+  {
+    id: 3,
+    label: 'Coffee',
+    emoji: 'coffee'
+  },
+];
+
+let lastId = 3;
+
 export function createCategory(data) {
   return dispatch => {
     dispatch({type: actionTypes.CREATE_CATEGORY});
 
-    fetch('/api/v1/categories', {
-      method: 'POST',
-      headers: {
-        Accept: 'application/json',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(data)
-    })
-      .then(resp => resp.json())
-      .then(resp => {
-        dispatch({
-          type: actionTypes.CREATE_CATEGORY_SUCCESS,
-          category: resp.data
-        });
-      })
-      .catch(() => dispatch({
-        type: actionTypes.CREATE_CATEGORY_FAILURE
-      }));
+    const newId = ++lastId;
+
+    // Simulate fake network latency
+    window.setTimeout(() => {
+      const newCategory = {
+        ...data,
+        id: newId
+      };
+
+      mockCategories.push(newCategory);
+
+      dispatch({
+        type: actionTypes.CREATE_CATEGORY_SUCCESS,
+        category: newCategory
+      });
+    }, 1000);
   };
 }
 
@@ -29,17 +47,12 @@ export function retrieveCategories() {
   return dispatch => {
     dispatch({type: actionTypes.RETRIEVE_CATEGORIES});
 
-    fetch('/api/v1/categories')
-      .then(resp => resp.json())
-      .then(resp => {
-        dispatch({
-          type: actionTypes.RETRIEVE_CATEGORIES_SUCCESS,
-          categories: resp.data
-        });
-      })
-      .catch(() => dispatch({
-        type: actionTypes.RETRIEVE_CATEGORIES_FAILURE
-      }));
+    window.setTimeout(() => {
+      dispatch({
+        type: actionTypes.RETRIEVE_CATEGORIES_SUCCESS,
+        categories: [...mockCategories]
+      });
+    }, 1200);
   };
 }
 

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -1,0 +1,89 @@
+import actionTypes from './action-types';
+
+export function createCategory(data) {
+  return dispatch => {
+    dispatch({type: actionTypes.CREATE_CATEGORY});
+
+    fetch('/api/v1/categories', {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
+    })
+      .then(resp => resp.json())
+      .then(resp => {
+        dispatch({
+          type: actionTypes.CREATE_CATEGORY_SUCCESS,
+          category: resp.data
+        });
+      })
+      .catch(() => dispatch({
+        type: actionTypes.CREATE_CATEGORY_FAILURE
+      }));
+  };
+}
+
+export function retrieveCategories() {
+  return dispatch => {
+    dispatch({type: actionTypes.RETRIEVE_CATEGORIES});
+
+    fetch('/api/v1/categories')
+      .then(resp => resp.json())
+      .then(resp => {
+        dispatch({
+          type: actionTypes.RETRIEVE_CATEGORIES_SUCCESS,
+          categories: resp.data
+        });
+      })
+      .catch(() => dispatch({
+        type: actionTypes.RETRIEVE_CATEGORIES_FAILURE
+      }));
+  };
+}
+
+export function updateCategory(categoryId, data) {
+  return dispatch => {
+    dispatch({type: actionTypes.UPDATE_CATEGORY, categoryId});
+
+    fetch(`/api/v1/categories/${categoryId}`, {
+      method: 'PATCH',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(data)
+    })
+      .then(resp => resp.json())
+      .then(resp => {
+        dispatch({
+          type: actionTypes.UPDATE_CATEGORY_SUCCESS,
+          categoryId,
+          category: resp.data
+        });
+      })
+      .catch(() => dispatch({
+        type: actionTypes.UPDATE_CATEGORY_FAILURE,
+        categoryId
+      }));
+  };
+}
+
+export function deleteCategory(categoryId) {
+  return dispatch => {
+    dispatch({type: actionTypes.DELETE_CATEGORY, categoryId});
+
+    fetch(`/api/v1/categories/${categoryId}`, {method: 'DELETE'})
+      .then(() => {
+        dispatch({
+          type: actionTypes.DELETE_CATEGORY_SUCCESS,
+          categoryId
+        });
+      })
+      .catch(() => dispatch({
+        type: actionTypes.DELETE_CATEGORY_FAILURE,
+        categoryId
+      }));
+  };
+}

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -1,24 +1,8 @@
 import actionTypes from './action-types';
+import mockCategories from '../mock/categories';
 
-const mockCategories = [
-  {
-    id: 1,
-    label: 'Food',
-    emoji: 'apple'
-  },
-  {
-    id: 2,
-    label: 'Childcare',
-    emoji: null
-  },
-  {
-    id: 3,
-    label: 'Coffee',
-    emoji: 'coffee'
-  },
-];
-
-let lastId = 3;
+let categoriesLength = mockCategories.length;
+let lastId = mockCategories[categoriesLength - 1].id;
 
 export function createCategory(data) {
   return dispatch => {

--- a/client-src/redux/categories/action-types.js
+++ b/client-src/redux/categories/action-types.js
@@ -1,0 +1,9 @@
+import keyMirror from 'keymirror';
+import createAsyncConstants from '../util/create-async-constants';
+
+export default keyMirror(createAsyncConstants(
+  'CREATE_CATEGORY',
+  'RETRIEVE_CATEGORIES',
+  'UPDATE_CATEGORY',
+  'DELETE_CATEGORY'
+));

--- a/client-src/redux/categories/initial-state.js
+++ b/client-src/redux/categories/initial-state.js
@@ -1,0 +1,21 @@
+export default {
+  categories: null,
+
+  creatingCategory: false,
+  createCategorySuccess: false,
+  createCategoryFailure: false,
+
+  retrievingCategories: false,
+  retrieveCategoriesSuccess: false,
+  retrieveCategoriesFailure: false,
+
+  currentlyUpdating: [],
+  updatingCategory: false,
+  updateCategorySuccess: false,
+  updateCategoryFailure: false,
+
+  currentlyDeleting: [],
+  deletingCategory: false,
+  deleteCategorySuccess: false,
+  deleteCategoryFailure: false
+};

--- a/client-src/redux/categories/initial-state.js
+++ b/client-src/redux/categories/initial-state.js
@@ -1,5 +1,5 @@
 export default {
-  categories: null,
+  categories: [],
 
   creatingCategory: false,
   createCategorySuccess: false,

--- a/client-src/redux/categories/reducer.js
+++ b/client-src/redux/categories/reducer.js
@@ -158,7 +158,6 @@ export default (state = initialState, action) => {
       let current = state.currentlyDeleting;
       let id = action.categoryId;
       let currentlyDeleting = _.without(current, id);
-      currentlyDeleting.push(action.category);
 
       const rejectionFn = val => val.id === action.categoryId;
       let categories = _.reject(state.categories, rejectionFn);

--- a/client-src/redux/categories/reducer.js
+++ b/client-src/redux/categories/reducer.js
@@ -1,0 +1,204 @@
+import _ from 'lodash';
+import actionTypes from './action-types';
+import initialState from './initial-state';
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    // Create category
+    case actionTypes.CREATE_CATEGORY: {
+      return Object.assign({
+        ...state,
+        creatingCategory: true
+      });
+    }
+
+    case actionTypes.CREATE_CATEGORY_SUCCESS: {
+      let categories = [...state.categories];
+      categories.push(action.category);
+      return Object.assign({
+        ...state,
+        creatingCategory: false,
+        createCategorySuccess: true,
+        categories
+      });
+    }
+
+    case actionTypes.CREATE_CATEGORY_FAILURE: {
+      return Object.assign({
+        ...state,
+        creatingCategory: false,
+        createCategoryFailure: true
+      });
+    }
+
+    case actionTypes.DISMISS_CREATE_CATEGORY_SUCCESS_ALERT: {
+      return Object.assign({
+        ...state,
+        createCategorySuccess: false
+      });
+    }
+
+    case actionTypes.DISMISS_CREATE_CATEGORY_FAILURE_ALERT: {
+      return Object.assign({
+        ...state,
+        createCategoryFailure: false
+      });
+    }
+
+    // Retrieving categories
+    case actionTypes.RETRIEVE_CATEGORIES: {
+      return Object.assign({
+        ...state,
+        retrievingCategories: true
+      });
+    }
+
+    case actionTypes.RETRIEVE_CATEGORIES_SUCCESS: {
+      return Object.assign({
+        ...state,
+        retrievingCategories: false,
+        retrieveCategoriesSuccess: true,
+        categories: action.categories
+      });
+    }
+
+    case actionTypes.RETRIEVE_CATEGORIES_FAILURE: {
+      return Object.assign({
+        ...state,
+        retrievingCategories: false,
+        retrieveCategoriesFailure: true
+      });
+    }
+
+    case actionTypes.DISMISS_RETRIEVE_CATEGORIES_SUCCESS_ALERT: {
+      return Object.assign({
+        ...state,
+        retrieveCategoriesSuccess: false
+      });
+    }
+
+    case actionTypes.DISMISS_RETRIEVE_CATEGORIES_FAILURE_ALERT: {
+      return Object.assign({
+        ...state,
+        retrieveCategoriesFailure: false
+      });
+    }
+
+    // Update category
+    case actionTypes.UPDATE_CATEGORY: {
+      let currentlyUpdating = [...state.currentlyUpdating];
+      currentlyUpdating.push(action.categoryId);
+      return Object.assign({
+        ...state,
+        updatingCategory: true,
+        currentlyUpdating
+      });
+    }
+
+    case actionTypes.UPDATE_CATEGORY_SUCCESS: {
+      let current = state.currentlyUpdating;
+      let id = action.categoryId;
+      let currentlyUpdating = _.without(current, id);
+
+      let categories = ([...state.categories]).map(t => {
+        if (t.id !== action.categoryId) {
+          return t;
+        } else {
+          return action.category;
+        }
+      });
+
+      return Object.assign({
+        ...state,
+        updatingCategory: false,
+        updateCategorySuccess: true,
+        currentlyUpdating,
+        categories
+      });
+    }
+
+    case actionTypes.UPDATE_CATEGORY_FAILURE: {
+      let current = state.currentlyUpdating;
+      let id = action.categoryId;
+      let currentlyUpdating = _.without(current, id);
+      return Object.assign({
+        ...state,
+        updatingCategory: false,
+        updateCategoryFailure: true,
+        currentlyUpdating
+      });
+    }
+
+    case actionTypes.DISMISS_UPDATE_CATEGORY_SUCCESS_ALERT: {
+      return Object.assign({
+        ...state,
+        updateCategorySuccess: false
+      });
+    }
+
+    case actionTypes.DISMISS_UPDATE_CATEGORY_FAILURE_ALERT: {
+      return Object.assign({
+        ...state,
+        updateCategoryFailure: false
+      });
+    }
+
+    // Delete category
+    case actionTypes.DELETE_CATEGORY: {
+      let currentlyDeleting = [...state.currentlyDeleting];
+      currentlyDeleting.push(action.categoryId);
+      return Object.assign({
+        ...state,
+        deletingCategory: true,
+        currentlyDeleting
+      });
+    }
+
+    case actionTypes.DELETE_CATEGORY_SUCCESS: {
+      let current = state.currentlyDeleting;
+      let id = action.categoryId;
+      let currentlyDeleting = _.without(current, id);
+      currentlyDeleting.push(action.category);
+
+      const rejectionFn = val => val.id === action.categoryId;
+      let categories = _.reject(state.categories, rejectionFn);
+      return Object.assign({
+        ...state,
+        deletingCategory: false,
+        deleteCategorySuccess: true,
+        currentlyDeleting,
+        categories
+      });
+    }
+
+    case actionTypes.DELETE_CATEGORY_FAILURE: {
+      let current = state.currentlyDeleting;
+      let id = action.categoryId;
+      let currentlyDeleting = _.without(current, id);
+      return Object.assign({
+        ...state,
+        deletingCategory: false,
+        deleteCategoryFailure: true,
+        currentlyDeleting
+      });
+    }
+
+    case actionTypes.DISMISS_DELETE_CATEGORY_SUCCESS_ALERT: {
+      return Object.assign({
+        ...state,
+        deleteCategorySuccess: false
+      });
+    }
+
+    case actionTypes.DISMISS_DELETE_CATEGORY_FAILURE_ALERT: {
+      return Object.assign({
+        ...state,
+        deleteCategoryFailure: false
+      });
+    }
+
+    default: {
+      return state;
+    }
+  }
+};

--- a/client-src/redux/mock/categories.js
+++ b/client-src/redux/mock/categories.js
@@ -1,0 +1,88 @@
+// A list of mock categories
+export default [
+  {
+    id: 1,
+    label: 'Pets',
+    emoji: '🐶'
+  },
+  {
+    id: 2,
+    label: 'Gas',
+    emoji: '⛽️'
+  },
+  {
+    id: 3,
+    label: 'Electronics',
+    emoji: '💻'
+  },
+  {
+    id: 4,
+    label: 'Food & Groceries',
+    emoji: '🍎'
+  },
+  {
+    id: 5,
+    label: 'Travel',
+    emoji: null
+  },
+  {
+    id: 6,
+    label: 'Movies',
+    emoji: '🎬'
+  },
+  {
+    id: 7,
+    label: 'Coffee',
+    emoji: '☕️'
+  },
+  {
+    id: 8,
+    label: 'Alcohol',
+    emoji: '🍺'
+  },
+  {
+    id: 9,
+    label: 'Child care',
+    emoji: '👶'
+  },
+  {
+    id: 10,
+    label: 'Rent',
+    emoji: '🏡'
+  },
+  {
+    id: 11,
+    label: 'Education',
+    emoji: '📚'
+  },
+  {
+    id: 12,
+    label: 'Shopping',
+    emoji: '🛍'
+  },
+  {
+    id: 13,
+    label: 'Apple Store',
+    emoji: '🖥'
+  },
+  {
+    id: 14,
+    label: 'Video Games',
+    emoji: '🕹'
+  },
+  {
+    id: 15,
+    label: 'Charity',
+    emoji: '💸'
+  },
+  {
+    id: 16,
+    label: 'Donations',
+    emoji: '💸'
+  },
+  {
+    id: 17,
+    label: 'Music',
+    emoji: '🎶'
+  }
+];

--- a/client-src/redux/store.js
+++ b/client-src/redux/store.js
@@ -5,11 +5,13 @@ import connection from './connection/reducer';
 import categories from './categories/reducer';
 import transactions from './transactions/reducer';
 import history from './history/reducer';
+import alert from './alert/reducer';
 import ui from './ui/reducer';
 
 const reducers = combineReducers({
   transactions, categories,
-  connection, history, ui
+  connection, history, ui,
+  alert
 });
 
 export default createStore(

--- a/client-src/redux/store.js
+++ b/client-src/redux/store.js
@@ -2,12 +2,14 @@ import { createStore, combineReducers, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
 
 import connection from './connection/reducer';
+import categories from './categories/reducer';
 import transactions from './transactions/reducer';
 import history from './history/reducer';
 import ui from './ui/reducer';
 
 const reducers = combineReducers({
-  transactions, connection, history, ui
+  transactions, categories,
+  connection, history, ui
 });
 
 export default createStore(

--- a/client-src/redux/transactions/reducer.js
+++ b/client-src/redux/transactions/reducer.js
@@ -158,7 +158,6 @@ export default (state = initialState, action) => {
       let current = state.currentlyDeleting;
       let id = action.transactionId;
       let currentlyDeleting = _.without(current, id);
-      currentlyDeleting.push(action.transaction);
 
       const rejectionFn = val => val.id === action.transactionId;
       let transactions = _.reject(state.transactions, rejectionFn);

--- a/client-src/redux/ui/initial-state.js
+++ b/client-src/redux/ui/initial-state.js
@@ -1,3 +1,7 @@
 export default {
-  isMobileMenuVisible: false
+  isMobileMenuVisible: false,
+
+  showAlert: false,
+  alertStyle: 'info',
+  alertText: ''
 };


### PR DESCRIPTION
This begins adding in a semi-working, but mock, categories page.

- Mock async redux actions let you load mock categories, and delete those categories
- An alert appears when the category is successfully mock-deleted
- The categories page becomes disabled when user is offline
- Offline alert shows when the user is disconnected from the 'net

Todo:

- Modal to create and edit categories
- Emoji picker
- Desktop view
- Undo for categories