### PR TITLE
Prevent mobile nav from being tabbed when hidden

### DIFF
--- a/client-src/common/components/mobile-nav/index.js
+++ b/client-src/common/components/mobile-nav/index.js
@@ -11,7 +11,7 @@ export function MobileNav({isMobileMenuVisible}) {
 
   return (
     <div className={mobileNavClass}>
-      <Nav isMobileNav={true}/>
+      <Nav isMobileNav={true} isHidden={!isMobileMenuVisible}/>
     </div>
   );
 }

--- a/client-src/common/components/nav/index.js
+++ b/client-src/common/components/nav/index.js
@@ -4,18 +4,25 @@ import {connect} from 'react-redux';
 import {Link} from 'react-router';
 import * as uiActionCreators from '../../../redux/ui/action-creators';
 
-export function Nav({uiActions, isMobileNav}) {
+export function Nav({uiActions, isMobileNav, isHidden}) {
   // This ensures that the mobile nav gets closed anytime a link is clicked
   function onClickNavItem() {
     if (!isMobileNav) { return; }
     uiActions.toggleMobileMenu(false);
   }
 
+  // If the nav is hidden, then it cannot be tabbed to
+  const itemTabIndex = isHidden ? -1 : 0;
+
   let dashboardLink;
   if (isMobileNav) {
     dashboardLink = (
       <li>
-        <Link to="/" onClick={onClickNavItem} activeClassName="active">
+        <Link
+          to="/"
+          onClick={onClickNavItem}
+          activeClassName="active"
+          tabIndex={itemTabIndex}>
           Dashboard
         </Link>
       </li>
@@ -27,17 +34,29 @@ export function Nav({uiActions, isMobileNav}) {
       <ul className="main-nav-list">
         {dashboardLink}
         <li>
-          <Link to="/transactions" onClick={onClickNavItem} activeClassName="active">
+          <Link
+            to="/transactions"
+            onClick={onClickNavItem}
+            activeClassName="active"
+            tabIndex={itemTabIndex}>
             Transactions
           </Link>
         </li>
         <li>
-          <Link to="/categories" onClick={onClickNavItem} activeClassName="active">
+          <Link
+            to="/categories"
+            onClick={onClickNavItem}
+            activeClassName="active"
+            tabIndex={itemTabIndex}>
             Categories
           </Link>
         </li>
         <li>
-          <Link to="/analytics" onClick={onClickNavItem} activeClassName="active">
+          <Link
+            to="/analytics"
+            onClick={onClickNavItem}
+            activeClassName="active"
+            tabIndex={itemTabIndex}>
             Analytics
           </Link>
         </li>


### PR DESCRIPTION
Atm if you tab through the app while the mobile nav is hidden, it will cycle through those hidden elements. This prevents that from happening.