### PR TITLE
Use alert for failed message send

### DIFF
--- a/client-src/common/components/alert/alert.styl
+++ b/client-src/common/components/alert/alert.styl
@@ -4,13 +4,14 @@
   left 0
   overflow hidden
   width 100%
-  line-height 48px
+  line-height 20px
   text-align center
   color #fff
   z-index 100
   display flex
   align-items center
   transition height 0.25s
+  padding 15px 0
 
   +respond-above($md-screen)
     left auto

--- a/client-src/common/components/alert/index.js
+++ b/client-src/common/components/alert/index.js
@@ -13,7 +13,7 @@ const defaultIconMap = {
 const Alert = React.createClass({
   componentWillMount() {
     // Dismissable alerts will dismiss themselves after 2 seconds
-    if (this.props.isDismissable) {
+    if (this.props.persistent) {
       this._autodestruct = window.setTimeout(() => {
         this.props.dismissCurrentAlert();
       }, 2000);
@@ -21,8 +21,20 @@ const Alert = React.createClass({
   },
 
   componentWillUnmount() {
+    const {
+      showNextAlert, onDismissAction,
+      dispatch
+    } = this.props;
+
     window.clearTimeout(this._autodestruct);
-    this.props.showNextAlert();
+
+    // If the alert was given an action to emit when it unmounts,
+    // then we call that now.
+    if (onDismissAction) {
+      dispatch(onDismissAction);
+    }
+
+    showNextAlert();
   },
 
   render() {
@@ -31,7 +43,6 @@ const Alert = React.createClass({
       icon,
       text,
       alertIsActive,
-      undoCallback,
       isDismissable,
       dismissCurrentAlert
     } = this.props;
@@ -52,15 +63,6 @@ const Alert = React.createClass({
       [materialIconClass]: true
     });
 
-    let undoText;
-    if (undoCallback) {
-      undoText = (
-        <button className="alert-undo" onClick={undoCallback}>
-          Undo
-        </button>
-      );
-    }
-
     let dismissIcon;
     if (isDismissable) {
       // If the modal is being hidden, then we can't dismiss it
@@ -75,12 +77,15 @@ const Alert = React.createClass({
       );
     }
 
+    const textHtml = {
+      __html: text
+    };
+
     return (
       <div className={alertClass}>
         <span className="alert-text">
           <i className={iconClass}></i>
-          {text}
-          {undoText}
+          <span dangerouslySetInnerHTML={textHtml}/>
         </span>
         {dismissIcon}
       </div>

--- a/client-src/meta/components/contact/index.js
+++ b/client-src/meta/components/contact/index.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
-import classNames from 'classnames';
 import React from 'react';
 import {bindActionCreators} from 'redux';
 import {reduxForm} from 'redux-form';
+import * as alertActionCreators from '../../../redux/alert/action-creators';
 import * as contactActionCreators from '../../../redux/contact/action-creators';
 
 const Contact = React.createClass({
@@ -24,13 +24,27 @@ const Contact = React.createClass({
     );
   },
 
+  componentWillReceiveProps(nextProps) {
+    const {sendMessageFailure} = this.props;
+    if (!sendMessageFailure && nextProps.sendMessageFailure) {
+      const resetMessageStateAction = contactActionCreators.resetMessageState();
+      const {queueAlert} = this.props.alertActions;
+      queueAlert({
+        style: 'danger',
+        text: 'Oops – there was an error.<br>Try that one more time?',
+        persistent: true,
+        isDismissable: true,
+        onDismissAction: resetMessageStateAction
+      });
+    }
+  },
+
   getContactForm() {
     const {
       fields: {subject, body},
       handleSubmit,
       contactActions,
-      sendingMessage,
-      sendMessageFailure
+      sendingMessage
     } = this.props;
 
     function onSubmit(data) {
@@ -41,11 +55,6 @@ const Contact = React.createClass({
     const sendBtnDisabled = sendingMessage;
 
     const placeholder = body.touched && body.error === 'empty' ? 'Please enter a message!' : '';
-
-    const errorClass = classNames({
-      'form-row form-error contact-page-error': true,
-      visible: sendMessageFailure
-    });
 
     return (
       <div>
@@ -69,9 +78,6 @@ const Contact = React.createClass({
               rows={6}
               spellCheck={true}
               {...body}/>
-          </div>
-          <div className={errorClass}>
-            The message failed to send. Please try again.
           </div>
           <div className="form-row contact-submit-row">
             <button
@@ -129,7 +135,8 @@ function mapStateToProps(state) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    contactActions: bindActionCreators(contactActionCreators, dispatch)
+    contactActions: bindActionCreators(contactActionCreators, dispatch),
+    alertActions: bindActionCreators(alertActionCreators, dispatch)
   };
 }
 

--- a/client-src/redux/alert/reducer.js
+++ b/client-src/redux/alert/reducer.js
@@ -3,7 +3,7 @@ import actionTypes from './action-types';
 import initialState from './initial-state';
 
 const validActionProps = [
-  'text', 'style',
+  'text', 'style', 'onDismissAction',
   'isDismissable',
   'icon', 'alertId'
 ];
@@ -59,6 +59,7 @@ export default (state = initialState, action) => {
       return {
         ...state,
         alertId: null,
+        undoAction: null,
         alertIsActive: false
       };
     }


### PR DESCRIPTION
Todo:

- [x] allow closing of alert to reset success state
- [x] turn back on success msg

---

Previously, the contact form would use a form error when there was a server error. It now uses the alert system. But this commit has a few other changes:

1. alerts now accept HTML msg's
2. the placeholder undo code has been removed
3. the display of alerts are temporarily broken in preparation for the updated design in #283
4. alerts now accept a dismiss action, which can be dispatched when the alert closes