### PR TITLE
Fix overflowing label in category list

### DIFF
--- a/client-src/categories/components/category-list-item/category-list-item.css
+++ b/client-src/categories/components/category-list-item/category-list-item.css
@@ -4,6 +4,11 @@
 
   .category-list-item-label-btn {
     cursor: pointer;
+    min-width: 0;
+  }
+
+  .category-list-item-label-btn-container {
+    display: flex;
   }
 
   .category-list-item-emoji {
@@ -13,7 +18,6 @@
     // 6px + 6px + 3px = 15px
     padding-right: 6px;
     margin-right: 3px;
-    width: 40px;
     min-width: 40px;
     text-align: center;
     display: inline-block;
@@ -30,5 +34,8 @@
     // 6px + 6px + 3px = 15px
     padding: 0 6px;
     margin-right: 15px;
+    flex-grow: 1;
+    // Overriding `text-align: center;` inherited from user agent stylesheets
+    text-align: left;
   }
 }

--- a/client-src/categories/components/category-list-item/index.js
+++ b/client-src/categories/components/category-list-item/index.js
@@ -20,10 +20,12 @@ export default function CategoryListItem(props) {
   return (
     <li className="resource-list-item category-list-item">
       <button className="category-list-item-label-btn" onClick={() => onClickEdit(category)}>
-        <span className="category-list-item-emoji" dangerouslySetInnerHTML={categoryEmojiHtml}/>
-        <span className="category-list-item-label">
-          {category.label}
-        </span>
+        <div className="category-list-item-label-btn-container">
+          <span className="category-list-item-emoji" dangerouslySetInnerHTML={categoryEmojiHtml}/>
+          <span className="category-list-item-label">
+            {category.label}
+          </span>
+        </div>
       </button>
 
       <button


### PR DESCRIPTION
Resolves #334

---

Also, TIL that Firefox doesn't allow for `display: flex;` on buttons, and that other browsers prob. shouldn't, either. :book: