### PR TITLE
DRY up the test tasks in the Gulpfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Track your finances.",
   "main": "client-dist/app.js",
   "scripts": {
-    "test": "gulp && npm run test:api",
+    "test": "npm run lint && npm run test:unit && npm run test:api",
+    "test:unit": "gulp test:unit",
     "test:api": "gulp test:api:integration",
     "pretest:api": "dropdb moolah_test_db -U postgres || true && createdb moolah_test_db -U postgres",
     "lint": "gulp lint",


### PR DESCRIPTION
Also adds task to run just the unit tests

Resolves #348 

---

One issue with the regular `gulp` task is that the integration test `beforeEach` runs for every test. This is super slow since it hits a real DB. Ideally I could separate out the two types of tests such that they didn't interfere even when run at the same time.