### PR TITLE
Specify engines in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,6 +6,10 @@
   "addons": [
     "heroku-postgresql:hobby-dev"
   ],
+  "engines": {
+    "node": "6.3.0",
+    "npm": "3.10.5"
+  },
   "env": {
     "NPM_CONFIG_PRODUCTION": {
       "description": "Ensures that all dependencies on installed during deployment.",


### PR DESCRIPTION
Atm Heroku just uses the latest Node release, and the bundled npm. This makes it a little more explicit about what should be used.