### PR TITLE
Add npm to package.json engines; remove engines from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,10 +6,6 @@
   "addons": [
     "heroku-postgresql:hobby-dev"
   ],
-  "engines": {
-    "node": "6.3.0",
-    "npm": "3.10.5"
-  },
   "env": {
     "NPM_CONFIG_PRODUCTION": {
       "description": "Ensures that all dependencies on installed during deployment.",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "url": "https://github.com/jmeas/moolah/issues"
   },
   "engines": {
-    "node": "6.3.0"
+    "node": "6.3.0",
+    "npm": "3.10.5"
   },
   "homepage": "https://github.com/jmeas/moolah",
   "devDependencies": {


### PR DESCRIPTION
Resolves #396

---

I must have misread the heroku docs, thinking that they meant specifying `engines` in app.json. But they meant package.json. This should help with #369 

---

It works! From the Heroku build log:

```
-----> Installing binaries
       engines.node (package.json):  6.3.0
       engines.npm (package.json):   3.10.5
```