### PR TITLE
Remove status from "errors" array in server errors

### DIFF
--- a/server/api/util/bad-request-map.js
+++ b/server/api/util/bad-request-map.js
@@ -26,8 +26,7 @@ function createErrors(originalErrors) {
     var kapowError = _.pick(Kapow(code, message), kapowAttrs);
     return {
       title: kapowError.title,
-      detail: kapowError.message,
-      status: kapowError.httpStatus
+      detail: kapowError.message
     };
   });
 }

--- a/server/api/util/server-errors.js
+++ b/server/api/util/server-errors.js
@@ -1,15 +1,10 @@
 'use strict';
 
-// The `code` in each error is duplicated because I don't think it's
-// worthwhile to write a introduce an abstraction for it. It would
-// DRY it up at the expense of how simple it is to read this file
-// to at a glance see the code of the response is, and its body.
 module.exports = {
   notFound: {
     code: 404,
     body() {
       return {
-        code: '404',
         title: 'Server Error',
         detail: 'There was an error while processing your request'
       };
@@ -20,7 +15,6 @@ module.exports = {
     code: 500,
     body() {
       return {
-        code: '500',
         title: 'Server Error',
         detail: 'There was an error while processing your request'
       };

--- a/test/integration/api/transactions/index.js
+++ b/test/integration/api/transactions/index.js
@@ -303,7 +303,6 @@ describe('Transactions', () => {
 
         it('should return the correct error', done => {
           const errors = [{
-            status: '400',
             title: 'Bad Request',
             detail: '"body.date" must be date format'
           }];
@@ -410,7 +409,6 @@ describe('Transactions', () => {
 
       it('should return the correct error', done => {
         const errors = [{
-          status: '400',
           title: 'Bad Request',
           detail: '"body.value" is required'
         }];
@@ -441,7 +439,6 @@ describe('Transactions', () => {
 
       it('should return the correct error', done => {
         const errors = [{
-          status: '400',
           title: 'Bad Request',
           detail: '"body.date" must be date format'
         }];

--- a/test/unit/server/api/util/bad-request-map.js
+++ b/test/unit/server/api/util/bad-request-map.js
@@ -1,10 +1,6 @@
-import requestErrorMap from '../../../server/api/util/bad-request-map';
+import requestErrorMap from '../../../../../server/api/util/bad-request-map';
 
 describe('requestErrorMap', () => {
-  it('should be a function', () => {
-    expect(requestErrorMap).to.be.a('function');
-  });
-
   describe('when passing in nothing', () => {
     it('should return an empty Array', () => {
       expect(requestErrorMap()).to.deep.equal([]);
@@ -25,7 +21,6 @@ describe('requestErrorMap', () => {
       }];
 
       var expected = [{
-        status: '400',
         title: 'Bad Request',
         detail: '"hello" is required'
       }];
@@ -45,11 +40,9 @@ describe('requestErrorMap', () => {
       }];
 
       var expected = [{
-        status: '400',
         title: 'Bad Request',
         detail: '"hello" is required'
       }, {
-        status: '400',
         title: 'Bad Request',
         detail: '"id" is the wrong type'
       }];


### PR DESCRIPTION
Resolves #399

---

The tl;dr is that I was mistaking "body" in the error generator to mean the actual body of the http response, when its the "body" of the individual error. So the error was returning like...

```js
{
  "errors": [{"status": "500"}]
}
```

which doesn't make much sense :v: