### PR TITLE
Update categories alerts

### DIFF
--- a/client-src/categories/components/delete-category-modal/index.js
+++ b/client-src/categories/components/delete-category-modal/index.js
@@ -6,23 +6,6 @@ import * as alertActionCreators from '../../../redux/alerts/action-creators';
 import * as categoriesActionCreators from '../../../redux/categories/action-creators';
 
 const DeleteCategoryModal = React.createClass({
-  componentWillUnmount() {
-    this.props.dismissError();
-  },
-
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.actionFailure && !this.props.actionFailure) {
-      const {queueAlert} = this.props.alertActions;
-      const dismissFailureAlert = categoriesActionCreators.resetDeleteCategoryResolution();
-      queueAlert({
-        style: 'danger',
-        text: 'Oops – there was an error.<br>Try that one more time?',
-        isDismissable: true,
-        onDismissAction: dismissFailureAlert
-      });
-    }
-  },
-
   render() {
     const props = this.props;
 

--- a/client-src/redux/alerts/initial-state.js
+++ b/client-src/redux/alerts/initial-state.js
@@ -1,4 +1,3 @@
 export default {
-  alerts: [],
-  animatingOutAlert: false
+  alerts: []
 };

--- a/client-src/redux/alerts/reducer.js
+++ b/client-src/redux/alerts/reducer.js
@@ -1,6 +1,7 @@
 import _ from 'lodash';
 import actionTypes from './action-types';
 import initialState from './initial-state';
+import categoriesActionTypes from '../categories/action-types';
 
 const validActionProps = [
   'text', 'style', 'onDismissAction',
@@ -13,17 +14,54 @@ export default (state = initialState, action) => {
 
   switch (action.type) {
     case actionTypes.QUEUE_ALERT: {
+      const clonedAlerts = _.cloneDeep(state.alerts);
       return {
         ...state,
-        alerts: [...state.alerts, alertAction],
+        alerts: [...clonedAlerts, alertAction],
       };
     }
 
     case actionTypes.DESTROY_FIRST_ALERT: {
+      const clonedAlerts = _.cloneDeep(state.alerts);
       return {
         ...state,
-        animatingOutAlert: false,
-        alerts: [...state.alerts.slice(1)]
+        alerts: clonedAlerts.slice(1)
+      };
+    }
+
+    case categoriesActionTypes.DELETE_CATEGORY_SUCCESS: {
+      const clonedAlerts = _.cloneDeep(state.alerts);
+      const id = _.uniqueId('alert-');
+      return {
+        ...state,
+        alerts: [
+          ...clonedAlerts,
+          {
+            id,
+            text: 'Category deleted',
+            style: 'success',
+            isDismissable: true,
+            persistent: false
+          }
+        ]
+      };
+    }
+
+    case categoriesActionTypes.DELETE_CATEGORY_FAILURE: {
+      const clonedAlerts = _.cloneDeep(state.alerts);
+      const id = _.uniqueId('alert-');
+      return {
+        ...state,
+        alerts: [
+          ...clonedAlerts,
+          {
+            id,
+            style: 'danger',
+            text: 'Oops – there was an error. Try that one more time?',
+            isDismissable: true,
+            persistent: false
+          }
+        ]
       };
     }
 

--- a/client-src/redux/alerts/reducer.js
+++ b/client-src/redux/alerts/reducer.js
@@ -27,13 +27,6 @@ export default (state = initialState, action) => {
       };
     }
 
-    case actionTypes.ANIMTE_OUT_ALERT: {
-      return {
-        ...state,
-        animatingOutAlert: true
-      };
-    }
-
     default: {
       return state;
     }

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -105,15 +105,12 @@ export function updateCategory(category) {
   };
 }
 
-export function resetDeleteCategoryResolution() {
-  return {
-    type: actionTypes.DELETE_CATEGORY_RESET_RESOLUTION
-  };
-}
-
 export function deleteCategory(categoryId) {
   return dispatch => {
-    dispatch({type: actionTypes.DELETE_CATEGORY});
+    dispatch({
+      type: actionTypes.DELETE_CATEGORY,
+      categoryId
+    });
 
     const req = xhr.del(
       `/api/v1/categories/${categoryId}`,
@@ -122,10 +119,11 @@ export function deleteCategory(categoryId) {
         if (req.aborted) {
           return;
         }
-        if (err) {
-          dispatch({type: actionTypes.DELETE_CATEGORY_FAILURE});
-        } else if (res.statusCode === 404) {
-          dispatch({type: actionTypes.DELETE_CATEGORY_FAILURE});
+        if (err || res.statusCode >= 400) {
+          dispatch({
+            type: actionTypes.DELETE_CATEGORY_FAILURE,
+            categoryId
+          });
         } else {
           dispatch({
             type: actionTypes.DELETE_CATEGORY_SUCCESS,

--- a/client-src/redux/categories/initial-state.js
+++ b/client-src/redux/categories/initial-state.js
@@ -13,9 +13,5 @@ export default {
   categoryIdBeingUpdated: null,
   updatingCategory: false,
   updateCategorySuccess: false,
-  updateCategoryFailure: false,
-
-  deletingCategory: false,
-  deleteCategorySuccess: false,
-  deleteCategoryFailure: false
+  updateCategoryFailure: false
 };

--- a/client-src/redux/categories/initial-state.js
+++ b/client-src/redux/categories/initial-state.js
@@ -1,5 +1,6 @@
 export default {
   categories: [],
+  categoriesMeta: [],
 
   creatingCategory: false,
   createCategorySuccess: false,

--- a/client-src/redux/categories/reducer.js
+++ b/client-src/redux/categories/reducer.js
@@ -184,37 +184,43 @@ export default (state = initialState, action) => {
 
     // Delete category
     case actionTypes.DELETE_CATEGORY: {
-      const categoriesMeta = state.categoriesMeta.map(c => {
-        return {
-          ...c,
-          isDeleting: c.id === action.categoryId
-        };
+      const clonedMeta = _.cloneDeep(state.categoriesMeta);
+      const categoriesMeta = clonedMeta.map(c => {
+        if (c.id !== action.categoryId) {
+          return c;
+        } else {
+          return {
+            ...c,
+            isDeleting: c.id === action.categoryId
+          };
+        }
       });
 
-      return Object.assign({
+      return {
         ...state,
-        categoriesMeta,
-        deletingCategory: true,
-      });
+        categoriesMeta
+      };
     }
 
     case actionTypes.DELETE_CATEGORY_SUCCESS: {
       const rejectionFn = val => val.id === action.categoryId;
-      let categories = _.reject(state.categories, rejectionFn);
-      let categoriesMeta = _.reject(state.categories, rejectionFn);
-      return Object.assign({
+      const clonedCategories = _.cloneDeep(state.categories);
+      const clonedMeta = _.cloneDeep(state.categoriesMeta);
+
+      let categories = _.reject(clonedCategories, rejectionFn);
+      let categoriesMeta = _.reject(clonedMeta, rejectionFn);
+      return {
         ...state,
-        deletingCategory: false,
-        deleteCategorySuccess: true,
         categories,
         categoriesMeta
-      });
+      };
     }
 
     case actionTypes.DELETE_CATEGORY_FAILURE: {
-      const categoriesMeta = state.categoriesMeta.map(c => {
+      const clonedMeta = _.cloneDeep(state.categoriesMeta);
+      const categoriesMeta = clonedMeta.map(c => {
         if (c.id !== action.categoryId) {
-          return {...c};
+          return c;
         } else {
           return {
             ...c,
@@ -223,20 +229,10 @@ export default (state = initialState, action) => {
         }
       });
 
-      return Object.assign({
+      return {
         ...state,
-        categoriesMeta,
-        deletingCategory: false,
-        deleteCategoryFailure: true,
-      });
-    }
-
-    case actionTypes.DELETE_CATEGORY_RESET_RESOLUTION: {
-      return Object.assign({
-        ...state,
-        deleteCategoryFailure: false,
-        deleteCategorySuccess: false
-      });
+        categoriesMeta
+      };
     }
 
     default: {

--- a/client-src/redux/categories/reducer.js
+++ b/client-src/redux/categories/reducer.js
@@ -2,6 +2,11 @@ import _ from 'lodash';
 import actionTypes from './action-types';
 import initialState from './initial-state';
 
+const initialResourceMetaState = {
+  isUpdating: false,
+  isDeleting: false
+};
+
 export default (state = initialState, action) => {
   switch (action.type) {
     case actionTypes.SET_CATEGORY_UPDATE_ID: {
@@ -29,11 +34,19 @@ export default (state = initialState, action) => {
     case actionTypes.CREATE_CATEGORY_SUCCESS: {
       let categories = [...state.categories];
       categories.push(action.category);
+      const categoriesMeta = [
+        ...state.categoriesMeta,
+        {
+          ...action.category,
+          ...initialResourceMetaState
+        }
+      ];
       return Object.assign({
         ...state,
         creatingCategory: false,
         createCategorySuccess: true,
-        categories
+        categories,
+        categoriesMeta
       });
     }
 
@@ -62,11 +75,19 @@ export default (state = initialState, action) => {
     }
 
     case actionTypes.RETRIEVE_CATEGORIES_SUCCESS: {
+      const categoriesMeta = action.categories.map(c => {
+        return {
+          ...c,
+          ...initialResourceMetaState
+        };
+      });
+
       return Object.assign({
         ...state,
         retrievingCategories: false,
         retrieveCategoriesSuccess: true,
-        categories: action.categories
+        categories: [...action.categories],
+        categoriesMeta
       });
     }
 
@@ -88,8 +109,16 @@ export default (state = initialState, action) => {
 
     // Update category
     case actionTypes.UPDATE_CATEGORY: {
+      const categoriesMeta = state.categoriesMeta.map(c => {
+        return {
+          ...c,
+          isUpdating: c.id === action.categoryId
+        };
+      });
+
       return Object.assign({
         ...state,
+        categoriesMeta,
         updatingCategory: true
       });
     }
@@ -105,17 +134,41 @@ export default (state = initialState, action) => {
         }
       });
 
+      const categoriesMeta = state.categoriesMeta.map(c => {
+        if (c.id !== action.categoryId) {
+          return {...c};
+        } else {
+          return {
+            ...c,
+            isUpdating: false
+          };
+        }
+      });
+
       return Object.assign({
         ...state,
         updatingCategory: false,
         updateCategorySuccess: true,
-        categories
+        categories,
+        categoriesMeta
       });
     }
 
     case actionTypes.UPDATE_CATEGORY_FAILURE: {
+      const categoriesMeta = state.categoriesMeta.map(c => {
+        if (c.id !== action.categoryId) {
+          return {...c};
+        } else {
+          return {
+            ...c,
+            isUpdating: false
+          };
+        }
+      });
+
       return Object.assign({
         ...state,
+        categoriesMeta,
         updatingCategory: false,
         updateCategoryFailure: true
       });
@@ -131,8 +184,16 @@ export default (state = initialState, action) => {
 
     // Delete category
     case actionTypes.DELETE_CATEGORY: {
+      const categoriesMeta = state.categoriesMeta.map(c => {
+        return {
+          ...c,
+          isDeleting: c.id === action.categoryId
+        };
+      });
+
       return Object.assign({
         ...state,
+        categoriesMeta,
         deletingCategory: true,
       });
     }
@@ -140,17 +201,31 @@ export default (state = initialState, action) => {
     case actionTypes.DELETE_CATEGORY_SUCCESS: {
       const rejectionFn = val => val.id === action.categoryId;
       let categories = _.reject(state.categories, rejectionFn);
+      let categoriesMeta = _.reject(state.categories, rejectionFn);
       return Object.assign({
         ...state,
         deletingCategory: false,
         deleteCategorySuccess: true,
-        categories
+        categories,
+        categoriesMeta
       });
     }
 
     case actionTypes.DELETE_CATEGORY_FAILURE: {
+      const categoriesMeta = state.categoriesMeta.map(c => {
+        if (c.id !== action.categoryId) {
+          return {...c};
+        } else {
+          return {
+            ...c,
+            isDeleting: false
+          };
+        }
+      });
+
       return Object.assign({
         ...state,
+        categoriesMeta,
         deletingCategory: false,
         deleteCategoryFailure: true,
       });

--- a/test/unit/client/redux/alerts/reducer.js
+++ b/test/unit/client/redux/alerts/reducer.js
@@ -1,0 +1,78 @@
+import _ from 'lodash';
+import reducer from '../../../../../client-src/redux/alerts/reducer';
+import initialState from '../../../../../client-src/redux/alerts/initial-state';
+import alertsActionTypes from '../../../../../client-src/redux/alerts/action-types';
+import categoryActionTypes from '../../../../../client-src/redux/categories/action-types';
+
+describe('alerts/reducer', function() {
+  beforeEach(() => {
+    stub(_, 'uniqueId').returns('asdf');
+  });
+
+  afterEach(() => {
+    _.uniqueId.restore();
+  });
+
+  describe('An action with no type', () => {
+    it('should return the initial state', () => {
+      expect(reducer(undefined, {})).to.deep.equal(initialState);
+    });
+  });
+
+  describe('DESTROY_FIRST_ALERT', () => {
+    it('should remove an alert from the queue', () => {
+      const state = {
+        alerts: [{id: 1}, {id: 2}, {id: 3}]
+      };
+      const action = {
+        type: alertsActionTypes.DESTROY_FIRST_ALERT
+      };
+      const newState = {
+        alerts: [{id: 2}, {id: 3}]
+      };
+      expect(reducer(state, action)).to.deep.equal(newState);
+    });
+  });
+
+  describe('DELETE_CATEGORY_SUCCESS', () => {
+    it('should add a new alert to the queue', () => {
+      const state = {
+        alerts: [{id: 1}, {id: 2}, {id: 3}]
+      };
+      const action = {
+        type: categoryActionTypes.DELETE_CATEGORY_SUCCESS
+      };
+      const newState = {
+        alerts: [{id: 1}, {id: 2}, {id: 3}, {
+          id: 'asdf',
+          text: 'Category deleted',
+          style: 'success',
+          isDismissable: true,
+          persistent: false
+        }]
+      };
+      expect(reducer(state, action)).to.deep.equal(newState);
+    });
+  });
+
+  describe('DELETE_CATEGORY_FAILURE', () => {
+    it('should add a new alert to the queue', () => {
+      const state = {
+        alerts: [{id: 1}, {id: 2}, {id: 3}]
+      };
+      const action = {
+        type: categoryActionTypes.DELETE_CATEGORY_FAILURE
+      };
+      const newState = {
+        alerts: [{id: 1}, {id: 2}, {id: 3}, {
+          id: 'asdf',
+          style: 'danger',
+          text: 'Oops – there was an error. Try that one more time?',
+          isDismissable: true,
+          persistent: false
+        }]
+      };
+      expect(reducer(state, action)).to.deep.equal(newState);
+    });
+  });
+});

--- a/test/unit/client/redux/categories/reducer.js
+++ b/test/unit/client/redux/categories/reducer.js
@@ -2,13 +2,40 @@ import reducer from '../../../../../client-src/redux/categories/reducer';
 // import initialState from '../../../../../client-src/redux/categories/initial-state';
 import actionTypes from '../../../../../client-src/redux/categories/action-types';
 
-// passing a category id should return a new state without that category
+describe('categories/reducer', () => {
+  describe('DELETE_CATEGORY', () => {
+    let state, action;
+    beforeEach(() => {
+      state = {
+        categories: [{id: 1}, {id: 2}, {id: 3}],
+        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+      };
+      action = {
+        type: actionTypes.DELETE_CATEGORY,
+        categoryId: 2
+      };
+    });
 
-describe('categories: reducer', () => {
+    it('should return a new state with `isDeleting` set to true for that category', () => {
+      var newState = {
+        categories: [{id: 1}, {id: 2}, {id: 3}],
+        categoriesMeta: [
+          {id: 1},
+          {id: 2, isDeleting: true},
+          {id: 3}
+        ]
+      };
+      expect(reducer(state, action)).to.deep.equal(newState);
+    });
+  });
+
   describe('DELETE_CATEGORY_SUCCESS', () => {
     let state, action;
     beforeEach(() => {
-      state = {categories: [{id: 1}, {id: 2}, {id: 3}]};
+      state = {
+        categories: [{id: 1}, {id: 2}, {id: 3}],
+        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+      };
       action = {
         type: actionTypes.DELETE_CATEGORY_SUCCESS,
         categoryId: 2
@@ -18,8 +45,33 @@ describe('categories: reducer', () => {
     it('should return a new state without the category in categories', () => {
       var newState = {
         categories: [{id: 1}, {id: 3}],
-        deletingCategory: false,
-        deleteCategorySuccess: true
+        categoriesMeta: [{id: 1}, {id: 3}]
+      };
+      expect(reducer(state, action)).to.deep.equal(newState);
+    });
+  });
+
+  describe('DELETE_CATEGORY_FAILURE', () => {
+    let state, action;
+    beforeEach(() => {
+      state = {
+        categories: [{id: 1}, {id: 2}, {id: 3}],
+        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+      };
+      action = {
+        type: actionTypes.DELETE_CATEGORY_FAILURE,
+        categoryId: 2
+      };
+    });
+
+    it('should return a new state with `isDeleting` set to false for that category', () => {
+      var newState = {
+        categories: [{id: 1}, {id: 2}, {id: 3}],
+        categoriesMeta: [
+          {id: 1},
+          {id: 2, isDeleting: false},
+          {id: 3}
+        ]
       };
       expect(reducer(state, action)).to.deep.equal(newState);
     });


### PR DESCRIPTION
As part of #363 

---

The new system will be:

- No more "global" state for each type of action (like deleting, updating, etc.)
- Instead, metadata will be stored for each resource
- Atm the only metadata is `isUpdating` and `isDeleting`
- That data only communicates whether a request is in flight or not
- Temporary UI statuses can be updated using reducers (like how alerts work in MM)

---

Todo:

- [x] fix tests
- [x] write additional tests for delete reducers
- [x] look into delete modal implementation. might be able to simplify that further