### PR TITLE
Update alert messages to be more specific

### DIFF
--- a/client-src/common/services/string-util.js
+++ b/client-src/common/services/string-util.js
@@ -1,0 +1,12 @@
+/* eslint import/prefer-default-export: 'off' */
+
+// If `str` is longer than `length`, then you'll get a version of the string
+// that is truncated with ellipses. Useful for displaying user-entered data
+// within sentences.
+export function truncateAt(str, length) {
+  if (str.length <= length) {
+    return str;
+  } else {
+    return `${str.slice(0, length)}…`;
+  }
+}

--- a/client-src/redux/alerts/reducer.js
+++ b/client-src/redux/alerts/reducer.js
@@ -3,6 +3,7 @@ import alertsActionTypes from './action-types';
 import categoriesActionTypes from '../categories/action-types';
 import contactActionTypes from '../contact/action-types';
 import initialState from './initial-state';
+import {truncateAt} from '../../common/services/string-util';
 
 const validActionProps = [
   'text', 'style', 'isDismissable', 'persistent',
@@ -32,13 +33,14 @@ export default (state = initialState, action) => {
     case categoriesActionTypes.CREATE_CATEGORY_SUCCESS: {
       const clonedAlerts = _.cloneDeep(state.alerts);
       const id = _.uniqueId('alert-');
+      const categoryLabel = truncateAt(action.category.label, 35);
       return {
         ...state,
         alerts: [
           ...clonedAlerts,
           {
             id,
-            text: 'Category created',
+            text: `Created "${categoryLabel}" category`,
             style: 'success',
             isDismissable: true,
             persistent: false
@@ -50,6 +52,7 @@ export default (state = initialState, action) => {
     case categoriesActionTypes.CREATE_CATEGORY_FAILURE: {
       const clonedAlerts = _.cloneDeep(state.alerts);
       const id = _.uniqueId('alert-');
+      const categoryLabel = truncateAt(action.category.label, 35);
       return {
         ...state,
         alerts: [
@@ -57,7 +60,7 @@ export default (state = initialState, action) => {
           {
             id,
             style: 'danger',
-            text: 'Oops – there was an error. Try that one more time?',
+            text: `There was an error while creating the "${categoryLabel}" category`,
             isDismissable: true,
             persistent: false
           }
@@ -68,13 +71,14 @@ export default (state = initialState, action) => {
     case categoriesActionTypes.UPDATE_CATEGORY_SUCCESS: {
       const clonedAlerts = _.cloneDeep(state.alerts);
       const id = _.uniqueId('alert-');
+      const categoryLabel = truncateAt(action.category.label, 35);
       return {
         ...state,
         alerts: [
           ...clonedAlerts,
           {
             id,
-            text: 'Category updated',
+            text: `Updated "${categoryLabel}" category`,
             style: 'success',
             isDismissable: true,
             persistent: false
@@ -86,6 +90,7 @@ export default (state = initialState, action) => {
     case categoriesActionTypes.UPDATE_CATEGORY_FAILURE: {
       const clonedAlerts = _.cloneDeep(state.alerts);
       const id = _.uniqueId('alert-');
+      const categoryLabel = truncateAt(action.category.label, 35);
       return {
         ...state,
         alerts: [
@@ -93,7 +98,7 @@ export default (state = initialState, action) => {
           {
             id,
             style: 'danger',
-            text: 'Oops – there was an error. Try that one more time?',
+            text: `There was an error while updating the "${categoryLabel}" category`,
             isDismissable: true,
             persistent: false
           }
@@ -104,13 +109,14 @@ export default (state = initialState, action) => {
     case categoriesActionTypes.DELETE_CATEGORY_SUCCESS: {
       const clonedAlerts = _.cloneDeep(state.alerts);
       const id = _.uniqueId('alert-');
+      const categoryLabel = truncateAt(action.category.label, 35);
       return {
         ...state,
         alerts: [
           ...clonedAlerts,
           {
             id,
-            text: 'Category deleted',
+            text: `Deleted "${categoryLabel}" category`,
             style: 'success',
             isDismissable: true,
             persistent: false
@@ -122,6 +128,7 @@ export default (state = initialState, action) => {
     case categoriesActionTypes.DELETE_CATEGORY_FAILURE: {
       const clonedAlerts = _.cloneDeep(state.alerts);
       const id = _.uniqueId('alert-');
+      const categoryLabel = truncateAt(action.category.label, 35);
       return {
         ...state,
         alerts: [
@@ -129,7 +136,7 @@ export default (state = initialState, action) => {
           {
             id,
             style: 'danger',
-            text: 'Oops – there was an error. Try that one more time?',
+            text: `There was an error while deleting the "${categoryLabel}" category`,
             isDismissable: true,
             persistent: false
           }
@@ -147,7 +154,7 @@ export default (state = initialState, action) => {
           {
             id,
             style: 'danger',
-            text: 'Oops – there was an error. Try that one more time?',
+            text: `Oops – there was an error while sending your message. Try submitting it one more time?`,
             isDismissable: true,
             persistent: false
           }

--- a/client-src/redux/categories/action-creators.js
+++ b/client-src/redux/categories/action-creators.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import xhr from 'xhr';
 import actionTypes from './action-types';
 
@@ -9,16 +10,25 @@ export function resetCreateCategoryResolution() {
 
 export function createCategory(data) {
   return dispatch => {
-    dispatch({type: actionTypes.CREATE_CATEGORY});
+    dispatch({
+      type: actionTypes.CREATE_CATEGORY,
+      category: data
+    });
 
     const req = xhr.post(
       '/api/v1/categories',
       {json: data},
       (err, res, body) => {
         if (req.aborted) {
-          dispatch({type: actionTypes.CREATE_CATEGORY_ABORTED});
+          dispatch({
+            type: actionTypes.CREATE_CATEGORY_ABORTED,
+            category: data
+          });
         } else if (err || res.statusCode >= 400) {
-          dispatch({type: actionTypes.CREATE_CATEGORY_FAILURE});
+          dispatch({
+            type: actionTypes.CREATE_CATEGORY_FAILURE,
+            category: data
+          });
         } else {
           dispatch({
             type: actionTypes.CREATE_CATEGORY_SUCCESS,
@@ -74,7 +84,7 @@ export function updateCategory(category) {
   return dispatch => {
     dispatch({
       type: actionTypes.UPDATE_CATEGORY,
-      categoryId: category.id
+      category
     });
 
     const {id} = category;
@@ -85,12 +95,12 @@ export function updateCategory(category) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.UPDATE_CATEGORY_ABORTED,
-            categoryId: category.id
+            category
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.UPDATE_CATEGORY_FAILURE,
-            categoryId: category.id
+            category
           });
         } else {
           dispatch({
@@ -106,10 +116,13 @@ export function updateCategory(category) {
 }
 
 export function deleteCategory(categoryId) {
-  return dispatch => {
+  return (dispatch, getState) => {
+    const categoryList = getState().categories.categories;
+    const categoryToDelete = _.find(categoryList, {id: categoryId});
+
     dispatch({
       type: actionTypes.DELETE_CATEGORY,
-      categoryId
+      category: categoryToDelete
     });
 
     const req = xhr.del(
@@ -119,17 +132,17 @@ export function deleteCategory(categoryId) {
         if (req.aborted) {
           dispatch({
             type: actionTypes.DELETE_CATEGORY_ABORTED,
-            categoryId
+            category: categoryToDelete
           });
         } else if (err || res.statusCode >= 400) {
           dispatch({
             type: actionTypes.DELETE_CATEGORY_FAILURE,
-            categoryId
+            category: categoryToDelete
           });
         } else {
           dispatch({
             type: actionTypes.DELETE_CATEGORY_SUCCESS,
-            categoryId
+            category: categoryToDelete
           });
         }
       }

--- a/client-src/redux/categories/reducer.js
+++ b/client-src/redux/categories/reducer.js
@@ -92,7 +92,7 @@ export default (state = initialState, action) => {
     // Update category
     case actionTypes.UPDATE_CATEGORY: {
       const categoriesMeta = state.categoriesMeta.map(c => {
-        if (c.id !== action.categoryId) {
+        if (c.id !== action.category.id) {
           return {...c};
         } else {
           return {
@@ -139,7 +139,7 @@ export default (state = initialState, action) => {
 
     case actionTypes.UPDATE_CATEGORY_FAILURE: {
       const categoriesMeta = state.categoriesMeta.map(c => {
-        if (c.id !== action.categoryId) {
+        if (c.id !== action.category.id) {
           return {...c};
         } else {
           return {
@@ -157,9 +157,10 @@ export default (state = initialState, action) => {
 
     case actionTypes.UPDATE_CATEGORY_ABORTED:
     case actionTypes.UPDATE_CATEGORY_RESET_RESOLUTION: {
+      const id = action.category ? action.category.id : action.categoryId;
       const clonedMeta = _.cloneDeep(state.categoriesMeta);
       const categoriesMeta = clonedMeta.map(c => {
-        if (c.id !== action.categoryId) {
+        if (c.id !== id) {
           return {...c};
         } else {
           return {
@@ -179,12 +180,12 @@ export default (state = initialState, action) => {
     case actionTypes.DELETE_CATEGORY: {
       const clonedMeta = _.cloneDeep(state.categoriesMeta);
       const categoriesMeta = clonedMeta.map(c => {
-        if (c.id !== action.categoryId) {
+        if (c.id !== action.category.id) {
           return c;
         } else {
           return {
             ...c,
-            isDeleting: c.id === action.categoryId
+            isDeleting: c.id === action.category.id
           };
         }
       });
@@ -196,7 +197,7 @@ export default (state = initialState, action) => {
     }
 
     case actionTypes.DELETE_CATEGORY_SUCCESS: {
-      const rejectionFn = val => val.id === action.categoryId;
+      const rejectionFn = val => val.id === action.category.id;
       const clonedCategories = _.cloneDeep(state.categories);
       const clonedMeta = _.cloneDeep(state.categoriesMeta);
 
@@ -213,7 +214,7 @@ export default (state = initialState, action) => {
     case actionTypes.DELETE_CATEGORY_ABORTED: {
       const clonedMeta = _.cloneDeep(state.categoriesMeta);
       const categoriesMeta = clonedMeta.map(c => {
-        if (c.id !== action.categoryId) {
+        if (c.id !== action.category.id) {
           return c;
         } else {
           return {

--- a/test/unit/client/common/services/string-util.js
+++ b/test/unit/client/common/services/string-util.js
@@ -1,0 +1,17 @@
+import {truncateAt} from '../../../../../client-src/common/services/string-util';
+
+describe('stringUtil', () => {
+  describe('truncateAt', () => {
+    it('should not truncate when the string is shorter than the length', () => {
+      expect(truncateAt('hello', 10)).to.equal('hello');
+    });
+
+    it('should not truncate when the string is equal to the length', () => {
+      expect(truncateAt('hello', 5)).to.equal('hello');
+    });
+
+    it('should truncate when the string is longer than the length', () => {
+      expect(truncateAt('hello', 2)).to.equal('he…');
+    });
+  });
+});

--- a/test/unit/client/redux/alerts/reducer.js
+++ b/test/unit/client/redux/alerts/reducer.js
@@ -64,12 +64,15 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
-        type: categoryActionTypes.CREATE_CATEGORY_SUCCESS
+        type: categoryActionTypes.CREATE_CATEGORY_SUCCESS,
+        category: {
+          label: 'sandwiches'
+        }
       };
       const newState = {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
-          text: 'Category created',
+          text: 'Created "sandwiches" category',
           style: 'success',
           isDismissable: true,
           persistent: false
@@ -85,13 +88,16 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
-        type: categoryActionTypes.CREATE_CATEGORY_FAILURE
+        type: categoryActionTypes.CREATE_CATEGORY_FAILURE,
+        category: {
+          label: 'pasta'
+        }
       };
       const newState = {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
           style: 'danger',
-          text: 'Oops – there was an error. Try that one more time?',
+          text: 'There was an error while creating the "pasta" category',
           isDismissable: true,
           persistent: false
         }]
@@ -106,12 +112,15 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
-        type: categoryActionTypes.UPDATE_CATEGORY_SUCCESS
+        type: categoryActionTypes.UPDATE_CATEGORY_SUCCESS,
+        category: {
+          label: 'oink'
+        }
       };
       const newState = {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
-          text: 'Category updated',
+          text: 'Updated "oink" category',
           style: 'success',
           isDismissable: true,
           persistent: false
@@ -127,13 +136,16 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
-        type: categoryActionTypes.UPDATE_CATEGORY_FAILURE
+        type: categoryActionTypes.UPDATE_CATEGORY_FAILURE,
+        category: {
+          label: 'asdf'
+        }
       };
       const newState = {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
           style: 'danger',
-          text: 'Oops – there was an error. Try that one more time?',
+          text: 'There was an error while updating the "asdf" category',
           isDismissable: true,
           persistent: false
         }]
@@ -148,12 +160,15 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
-        type: categoryActionTypes.DELETE_CATEGORY_SUCCESS
+        type: categoryActionTypes.DELETE_CATEGORY_SUCCESS,
+        category: {
+          label: 'sandwich'
+        }
       };
       const newState = {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
-          text: 'Category deleted',
+          text: 'Deleted "sandwich" category',
           style: 'success',
           isDismissable: true,
           persistent: false
@@ -169,13 +184,16 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
-        type: categoryActionTypes.DELETE_CATEGORY_FAILURE
+        type: categoryActionTypes.DELETE_CATEGORY_FAILURE,
+        category: {
+          label: 'pasta'
+        }
       };
       const newState = {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
           style: 'danger',
-          text: 'Oops – there was an error. Try that one more time?',
+          text: 'There was an error while deleting the "pasta" category',
           isDismissable: true,
           persistent: false
         }]
@@ -196,7 +214,7 @@ describe('alerts/reducer', function() {
         alerts: [{id: 1}, {id: 2}, {id: 3}, {
           id: 'asdf',
           style: 'danger',
-          text: 'Oops – there was an error. Try that one more time?',
+          text: 'Oops – there was an error while sending your message. Try submitting it one more time?',
           isDismissable: true,
           persistent: false
         }]

--- a/test/unit/client/redux/categories/action-creators.js
+++ b/test/unit/client/redux/categories/action-creators.js
@@ -27,7 +27,8 @@ describe('categories/actionCreators', function() {
       thunk(this.dispatch);
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
-        type: actionTypes.CREATE_CATEGORY
+        type: actionTypes.CREATE_CATEGORY,
+        category: {label: 'pizza'}
       });
       expect(this.dispatch).to.have.been.calledBefore(xhr.post);
     });
@@ -59,7 +60,11 @@ describe('categories/actionCreators', function() {
         }
       });
       expect(this.dispatch).to.not.have.been.calledWith({
-        type: actionTypes.CREATE_CATEGORY_FAILURE
+        type: actionTypes.CREATE_CATEGORY_FAILURE,
+        category: {
+          id: 10,
+          label: 'pizza'
+        }
       });
     });
 
@@ -69,10 +74,12 @@ describe('categories/actionCreators', function() {
       req.abort();
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
-        type: actionTypes.CREATE_CATEGORY
+        type: actionTypes.CREATE_CATEGORY,
+        category: {label: 'pizza'}
       });
       expect(this.dispatch).to.have.been.calledWith({
-        type: actionTypes.CREATE_CATEGORY_ABORTED
+        type: actionTypes.CREATE_CATEGORY_ABORTED,
+        category: {label: 'pizza'}
       });
     });
 
@@ -83,13 +90,11 @@ describe('categories/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.CREATE_CATEGORY_SUCCESS,
-        category: {
-          id: 10,
-          label: 'pizza'
-        }
+        category: {label: 'pizza'}
       });
       expect(this.dispatch).to.have.been.calledWith({
-        type: actionTypes.CREATE_CATEGORY_FAILURE
+        type: actionTypes.CREATE_CATEGORY_FAILURE,
+        category: {label: 'pizza'}
       });
     });
   });
@@ -188,7 +193,7 @@ describe('categories/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
         type: actionTypes.UPDATE_CATEGORY,
-        categoryId: 10
+        category: {id: 10, label: 'pizza'}
       });
       expect(this.dispatch).to.have.been.calledBefore(xhr.patch);
     });
@@ -221,7 +226,10 @@ describe('categories/actionCreators', function() {
       });
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.UPDATE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {
+          id: 2,
+          label: 'pizza'
+        }
       });
     });
 
@@ -232,11 +240,17 @@ describe('categories/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.UPDATE_CATEGORY,
-        categoryId: 2
+        category: {
+          id: 2,
+          label: 'pizza'
+        }
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.UPDATE_CATEGORY_ABORTED,
-        categoryId: 2
+        category: {
+          id: 2,
+          label: 'pizza'
+        }
       });
     });
 
@@ -254,26 +268,45 @@ describe('categories/actionCreators', function() {
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.UPDATE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {
+          id: 2,
+          label: 'pizza'
+        }
       });
     });
   });
 
   describe('deleteCategory', () => {
+    beforeEach(() => {
+      this.getState = function() {
+        return {
+          categories: {
+            categories: [
+              {id: 2, label: 'pizza'},
+              {id: 10, label: 'what'}
+            ]
+          }
+        };
+      };
+    });
+
     it('should dispatch a begin action before making the request', () => {
       const thunk = actionCreators.deleteCategory(2);
-      thunk(this.dispatch);
+      thunk(this.dispatch, this.getState);
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
         type: actionTypes.DELETE_CATEGORY,
-        categoryId: 2
+        category: {
+          id: 2,
+          label: 'pizza'
+        }
       });
       expect(this.dispatch).to.have.been.calledBefore(xhr.del);
     });
 
     it('should generate the expected request', () => {
       const thunk = actionCreators.deleteCategory(2);
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       expect(req).to.be.instanceof(this.FakeXMLHttpRequest);
       expect(req.url).to.equal('/api/v1/categories/2');
       expect(req.method).to.equal('DELETE');
@@ -281,46 +314,46 @@ describe('categories/actionCreators', function() {
 
     it('should respond appropriately when there are no errors', () => {
       const thunk = actionCreators.deleteCategory(2);
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.respond(200);
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.DELETE_CATEGORY_SUCCESS,
-        categoryId: 2
+        category: {id: 2, label: 'pizza'}
       });
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.DELETE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {id: 2, label: 'pizza'}
       });
     });
 
     it('should respond appropriately when aborted', () => {
       const thunk = actionCreators.deleteCategory(2);
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.abort();
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.DELETE_CATEGORY,
-        categoryId: 2
+        category: {id: 2, label: 'pizza'}
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.DELETE_CATEGORY_ABORTED,
-        categoryId: 2
+        category: {id: 2, label: 'pizza'}
       });
     });
 
     it('should respond appropriately when a error status code is returned', () => {
       const thunk = actionCreators.deleteCategory(2);
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.respond(500);
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.DELETE_CATEGORY_SUCCESS,
-        categoryId: 2
+        category: {id: 2, label: 'pizza'}
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.DELETE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {id: 2, label: 'pizza'}
       });
     });
   });

--- a/test/unit/client/redux/categories/reducer.js
+++ b/test/unit/client/redux/categories/reducer.js
@@ -65,7 +65,13 @@ describe('categories/reducer', function() {
         categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'PENDING'
       };
-      const action = {type: actionTypes.CREATE_CATEGORY_FAILURE};
+      const action = {
+        type: actionTypes.CREATE_CATEGORY_FAILURE,
+        category: {
+          id: 4,
+          pasta: 'yum'
+        }
+      };
       var newState = {
         categories: [{id: 1}, {id: 2}, {id: 3}],
         categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
@@ -82,7 +88,13 @@ describe('categories/reducer', function() {
         categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'PENDING'
       };
-      const action = {type: actionTypes.CREATE_CATEGORY_ABORTED};
+      const action = {
+        type: actionTypes.CREATE_CATEGORY_ABORTED,
+        category: {
+          id: 4,
+          pasta: 'yum'
+        }
+      };
       var newState = {
         categories: [{id: 1}, {id: 2}, {id: 3}],
         categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
@@ -185,7 +197,9 @@ describe('categories/reducer', function() {
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
       var newState = {
         categories: [{id: 1}, {id: 2}, {id: 3}],
@@ -236,7 +250,9 @@ describe('categories/reducer', function() {
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
       var newState = {
         categories: [{id: 1}, {id: 2}, {id: 3}],
@@ -262,7 +278,9 @@ describe('categories/reducer', function() {
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY_ABORTED,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
       var newState = {
         categories: [{id: 1}, {id: 2}, {id: 3}],
@@ -288,7 +306,9 @@ describe('categories/reducer', function() {
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY_RESET_RESOLUTION,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
       var newState = {
         categories: [{id: 1}, {id: 2}, {id: 3}],
@@ -311,7 +331,9 @@ describe('categories/reducer', function() {
       };
       action = {
         type: actionTypes.DELETE_CATEGORY,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
     });
 
@@ -337,7 +359,9 @@ describe('categories/reducer', function() {
       };
       action = {
         type: actionTypes.DELETE_CATEGORY_SUCCESS,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
     });
 
@@ -359,7 +383,9 @@ describe('categories/reducer', function() {
       };
       action = {
         type: actionTypes.DELETE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
     });
 
@@ -385,7 +411,9 @@ describe('categories/reducer', function() {
       };
       action = {
         type: actionTypes.DELETE_CATEGORY_FAILURE,
-        categoryId: 2
+        category: {
+          id: 2
+        }
       };
     });
 


### PR DESCRIPTION
Also begins making the action creators more consistent

---

I haven't been a big fan of the generic "Category created" etc. messages in the app. If you get 3 alerts in a row of the same type, it's not clear what each is for.

This update makes it say the category, so, for instance,

> Created "Pasta" category

It also moves the verb to be the first word to make it more clear which CRUD action the alert is for.