### PR TITLE
Update appearance of modal

### DIFF
--- a/client-src/categories/components/delete-category-modal/delete-cateogory-modal.css
+++ b/client-src/categories/components/delete-category-modal/delete-cateogory-modal.css
@@ -1,8 +1,3 @@
 .deleteCategoryModal-container {
-  width: 255px;
-}
-
-.deleteCategoryModal-deleteBtn,
-.deleteCategoryModal-cancelBtn {
-  width: 50%;
+  width: 320px;
 }

--- a/client-src/categories/components/delete-category-modal/index.js
+++ b/client-src/categories/components/delete-category-modal/index.js
@@ -7,9 +7,9 @@ export default function DeleteCategoryModal(props) {
   return (
     <div className="deleteCategoryModal">
       <h1 className="modal-title">
-        Delete "{category.label}"?
+        Delete "{category.label}" category?
       </h1>
-      <div className="form-row">
+      <div className="modal-footer">
         <button
           onClick={() => onClickCancel()}
           className="btn btn-line deleteCategoryModal-cancelBtn"

--- a/client-src/categories/components/modify-category-modal/create-category-modal.css
+++ b/client-src/categories/components/modify-category-modal/create-category-modal.css
@@ -1,5 +1,5 @@
 .modifyCategoryModal-container {
-  width: 255px;
+  width: 320px;
 }
 
 .createCategoryModal {
@@ -16,11 +16,6 @@
     &:hover {
       background: #fafafa;
     }
-  }
-
-  .createCategoryModal-confirmBtn,
-  .createCategoryModal-cancelBtn {
-    width: 50%;
   }
 
   .newCategoryName {

--- a/client-src/categories/components/modify-category-modal/index.js
+++ b/client-src/categories/components/modify-category-modal/index.js
@@ -105,8 +105,11 @@ const ModifyCategoryModal = React.createClass({
         <h1 className="modal-title">
           {modalTitle}
         </h1>
-        {errorEl}
-        <form onSubmit={onFormSubmit}>
+        <form
+          onSubmit={onFormSubmit}
+          id="modify-category-modal-form"
+          className="modal-body">
+          {errorEl}
           <div className="form-row">
             <div className="createCategoryModal-emojiSelect">
               🙃
@@ -124,23 +127,24 @@ const ModifyCategoryModal = React.createClass({
               maxLength={35}
               {...label}/>
           </div>
-          <div className="form-row">
-            <button
-              type="button"
-              onClick={onClickCancelBtn}
-              className="btn btn-line createCategoryModal-cancelBtn"
-              disabled={confirmInProgress}
-              onMouseDown={this.mouseDownCancel}>
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className="btn btn-info createCategoryModal-confirmBtn"
-              disabled={confirmInProgress || treatFormInvalid}>
-              {confirmText}
-            </button>
-          </div>
         </form>
+        <div className="modal-footer">
+          <button
+            type="button"
+            onClick={onClickCancelBtn}
+            className="btn btn-line createCategoryModal-cancelBtn"
+            disabled={confirmInProgress}
+            onMouseDown={this.mouseDownCancel}>
+            Cancel
+          </button>
+          <button
+            form="modify-category-modal-form"
+            type="submit"
+            className="btn btn-info createCategoryModal-confirmBtn"
+            disabled={confirmInProgress || treatFormInvalid}>
+            {confirmText}
+          </button>
+        </div>
       </div>
     );
   }

--- a/client-src/common/components/modal/modal.css
+++ b/client-src/common/components/modal/modal.css
@@ -16,27 +16,46 @@
   max-width: 85%;
   // When the header doesn't span the full width, then all of the whitespace
   // around it makes the top appear visually to have more padding than it does
-  padding: 22px 27px 27px;
+  //padding: 22px 27px 27px;
   box-shadow: 0 0 100px rgba(0, 0, 0, 0.25);
   margin: 0 auto;
   margin-top: 20vh;
 
+  .modal-container {
+    width: 320px;
+  }
+
   .modal-title {
     font-size: 17px;
     font-weight: normal;
-    padding: 0;
-    margin: 0 0 15px;
+    padding: 7px 15px;
+    margin: 0;
     text-align: center;
+    border-bottom: 1px solid #eaeaea;
+
+    + .modal-footer {
+      position: relative;
+      top: -1px;
+    }
   }
 
-  .modal-form-invalid {
-    .modal-title {
-      margin-bottom: 6px;
-    }
+  .modal-body {
+    padding: 15px;
   }
 
   .modal-error {
     text-align: center;
     margin-bottom: 13px;
+  }
+
+  .modal-footer {
+    padding: 7px 15px;
+    border-top: 1px solid #eaeaea;
+    display: flex;
+    justify-content: flex-end;
+
+    .btn {
+      margin-left: 10px;
+    }
   }
 }

--- a/test/unit/client/categories/components/delete-category-modal.js
+++ b/test/unit/client/categories/components/delete-category-modal.js
@@ -26,7 +26,7 @@ describe('DeleteCategoryModal', function() {
 
     it('should have the category label in the title', () => {
       const wrapper = this.generator.shallow();
-      expect(wrapper.find('.modal-title').text()).to.equal('Delete "pasta"?');
+      expect(wrapper.find('.modal-title').text()).to.equal('Delete "pasta" category?');
     });
 
     describe('cancel button', () => {

--- a/test/unit/client/categories/components/modify-category-modal.js
+++ b/test/unit/client/categories/components/modify-category-modal.js
@@ -190,14 +190,14 @@ describe('ModifyCategoryModal', function() {
 
       describe('cancel button', () => {
         it('should exist', () => {
-          const form = this.generator.shallow().find('form');
-          const cancelBtn = form.find('.createCategoryModal-cancelBtn');
+          const wrapper = this.generator.shallow();
+          const cancelBtn = wrapper.find('.createCategoryModal-cancelBtn');
           expect(cancelBtn).to.have.length(1);
         });
 
         it('should not be disabled when no confirm is in progress', () => {
-          const form = this.generator.shallow().find('form');
-          const cancelBtn = form.find('.createCategoryModal-cancelBtn');
+          const wrapper = this.generator.shallow();
+          const cancelBtn = wrapper.find('.createCategoryModal-cancelBtn');
           expect(cancelBtn.prop('disabled')).to.be.falsey;
         });
 
@@ -210,28 +210,28 @@ describe('ModifyCategoryModal', function() {
               }
             }
           };
-          const form = this.generator.shallow(props).find('form');
-          const cancelBtn = form.find('.createCategoryModal-cancelBtn');
+          const wrapper = this.generator.shallow(props);
+          const cancelBtn = wrapper.find('.createCategoryModal-cancelBtn');
           expect(cancelBtn.prop('disabled')).to.be.falsey;
         });
 
         it('should be disabled when a creation is in progress', () => {
           const props = {confirmInProgress: true};
-          const form = this.generator.shallow(props).find('form');
-          const cancelBtn = form.find('.createCategoryModal-cancelBtn');
+          const wrapper = this.generator.shallow(props);
+          const cancelBtn = wrapper.find('.createCategoryModal-cancelBtn');
           expect(cancelBtn.prop('disabled')).to.be.true;
         });
 
         it('should have the right text', () => {
-          const form = this.generator.shallow().find('form');
-          const cancelBtn = form.find('.createCategoryModal-cancelBtn');
+          const wrapper = this.generator.shallow();
+          const cancelBtn = wrapper.find('.createCategoryModal-cancelBtn');
           expect(cancelBtn.text()).to.equal('Cancel');
         });
 
         it('should preventDefault and call `onClickCancel` when clicked', () => {
           const preventDefault = stub();
-          const form = this.generator.shallow().find('form');
-          const cancelBtn = form.find('.createCategoryModal-cancelBtn');
+          const wrapper = this.generator.shallow();
+          const cancelBtn = wrapper.find('.createCategoryModal-cancelBtn');
           cancelBtn.simulate('click', {preventDefault});
           expect(preventDefault).to.have.been.calledOnce;
           expect(this.onClickCancel).to.have.been.calledOnce;
@@ -240,20 +240,20 @@ describe('ModifyCategoryModal', function() {
 
       describe('confirm button', () => {
         it('should exist', () => {
-          const form = this.generator.shallow().find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow();
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn).to.have.length(1);
         });
 
         it('should be the submit button', () => {
-          const form = this.generator.shallow().find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow();
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.prop('type')).to.equal('submit');
         });
 
         it('should not be disabled when there are no errors & no save in progress', () => {
-          const form = this.generator.shallow().find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow();
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.prop('disabled')).to.be.falsey;
         });
 
@@ -266,8 +266,8 @@ describe('ModifyCategoryModal', function() {
               }
             }
           };
-          const form = this.generator.shallow(props).find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow(props);
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.prop('disabled')).to.be.falsey;
         });
 
@@ -280,33 +280,33 @@ describe('ModifyCategoryModal', function() {
               }
             }
           };
-          const form = this.generator.shallow(props).find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow(props);
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.prop('disabled')).to.be.true;
         });
 
         it('should be disabled when a creation is in progress', () => {
           const props = {confirmInProgress: true};
-          const form = this.generator.shallow(props).find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow(props);
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.prop('disabled')).to.be.true;
         });
 
         it('should have the right text', () => {
-          const form = this.generator.shallow().find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow();
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.text()).to.equal('Create');
         });
 
         it('should have the right text when edit mode is true', () => {
-          const form = this.generator.shallow({isEditMode: true}).find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow({isEditMode: true});
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.text()).to.equal('Edit');
         });
 
         it('should have the right text when a create is in progress', () => {
-          const form = this.generator.shallow({confirmInProgress: true}).find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow({confirmInProgress: true});
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.text()).to.equal('Creating...');
         });
 
@@ -315,8 +315,8 @@ describe('ModifyCategoryModal', function() {
             confirmInProgress: true,
             isEditMode: true
           };
-          const form = this.generator.shallow(props).find('form');
-          const confirmBtn = form.find('.createCategoryModal-confirmBtn');
+          const wrapper = this.generator.shallow(props);
+          const confirmBtn = wrapper.find('.createCategoryModal-confirmBtn');
           expect(confirmBtn.text()).to.equal('Editing...');
         });
       });


### PR DESCRIPTION
This updates the modals with the new design. I might also want to take the time to refactor the modal at this time? Or maybe that will come later?

Things to think about:

1. the wrapping element in the `Modal` component that just gets a class is bad. Why not just set the class in the component being rendered...?
2. Specifying width on each modal is bad. There should be a default width that's overridable
3. No pattern for the close btn in the modal title. Should that be a separate component...?