### PR TITLE
Update redirect URL for Google in production

### DIFF
--- a/server/util/configure-passport.js
+++ b/server/util/configure-passport.js
@@ -38,10 +38,15 @@ module.exports = function(db) {
       );
   }
 
+  // These should be configurable via env variables
+  const localUrl = 'http://localhost:5000';
+  const prodUrl = 'https://www.moolah-app.com';
+  const appUrlBase = process.env.NODE_ENV === 'development' ? localUrl : prodUrl;
+
   const googleStrategy = new GoogleStrategy({
     clientID: process.env.GOOGLE_CLIENT_ID,
     clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-    callbackURL: 'http://localhost:5000/auth/google/callback'
+    callbackURL: `${appUrlBase}/auth/google/callback`
   }, passportCallback);
 
   passport.use('google', googleStrategy);


### PR DESCRIPTION
This is a quick solution to test that logging in does, in fact, work in prod. A follow up PR can make this use a root URL set by the env; that way, we can get this working locally, on staging, and in prod.