### PR TITLE
Convert to Webpack 2 and Webpack CLI

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -1,25 +1,13 @@
 const gulp = require('gulp');
-const path = require('path');
 const loadPlugins = require('gulp-load-plugins');
 const precss = require('precss');
 const cssnano = require('cssnano');
 const postcssSass = require('postcss-scss');
 const easyImport = require('postcss-easy-import');
-const webpack = require('webpack');
-const webpackStream = require('webpack-stream');
 const runSequence = require('run-sequence');
-const manifest = require('../package.json');
-
-// Gather the library data from `package.json`
-const config = manifest.babelBoilerplateOptions;
-const mainFile = manifest.main;
-const destinationFolder = path.dirname(mainFile);
-const exportFileName = path.basename(mainFile, path.extname(mainFile));
 
 const $ = loadPlugins();
 const productionMode = process.env.NODE_ENV === 'production';
-
-var working = false;
 
 exports.buildCss = () => {
   const processors = [
@@ -47,66 +35,14 @@ exports.buildCss = () => {
     .pipe($.livereload());
 };
 
-function watch() {
-  return $.watch([
-    // Just in case the CSS task changes
-    'gulpfile.babel.js',
-    './client-src/**/*.css'
-  ], exports.buildCss);
-}
-
-exports.buildJavaScript = () => {
-  var firstBuild = true;
-
-  const webpackPlugins = [];
-  if (productionMode) {
-    webpackPlugins.push(new webpack.EnvironmentPlugin(['NODE_ENV']));
-  }
-
-  return gulp.src(path.join('client-src', `${config.entryFileName}.js`))
-    .pipe($.plumber())
-    .pipe(webpackStream({
-      watch: working,
-      output: {
-        filename: `${exportFileName}.js`
-      },
-      module: {
-        loaders: [
-          {test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader'}
-        ]
-      },
-      plugins: webpackPlugins,
-      devtool: 'source-map'
-    }, null, () => {
-      if (!working) {
-        return;
-      }
-
-      if (firstBuild) {
-        $.livereload.listen({port: 35729, host: 'localhost', start: true});
-        watch();
-      } else {
-        $.livereload.reload('http://localhost:5000');
-      }
-      firstBuild = false;
-    }))
-    // We need to remove the source maps so that Uglify doesn't explode on them.
-    .pipe($.if(productionMode, $.filter('**/*.js')))
-    .pipe($.if(productionMode, $.sourcemaps.init({loadMaps: true})))
-    .pipe($.if(productionMode, $.uglify()))
-    .pipe($.if(productionMode, $.sourcemaps.write('./')))
-    .pipe(gulp.dest(destinationFolder));
-};
-
 exports.build = done => {
   runSequence(
     ['lint', 'clean'],
-    ['build-css', 'build-javascript'],
+    ['build-css'],
     done
   );
 };
 
 exports.work = done => {
-  working = true;
   runSequence('build', done);
 };

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -1,11 +1,7 @@
 const gulp = require('gulp');
 const loadPlugins = require('gulp-load-plugins');
-const glob = require('glob');
 const {Instrumenter} = require('isparta');
-const webpack = require('webpack');
-const webpackStream = require('webpack-stream');
 const mochaGlobals = require('../test/setup/.globals');
-const {lintJs} = require('./lint');
 
 const $ = loadPlugins();
 
@@ -40,7 +36,6 @@ exports.coverage = (done) => {
     'client-src/**/*.js',
     'server/**/*.js',
     '!client-src/vendor/**/*.js',
-    '!mock-server/**/*.js',
   ])
     .pipe($.istanbul({
       instrumenter: Instrumenter,
@@ -57,50 +52,4 @@ exports.coverage = (done) => {
 // Run the headless unit tests as you make changes.
 exports.watchTests = () => {
   $.watch(watchFiles, exports.test);
-};
-
-exports.testBrowser = () => {
-  // Our testing bundle is made up of our unit tests, which
-  // should individually load up pieces of our application.
-  // We also include the browser setup file.
-  const testFiles = glob.sync('./test/unit/**/*.js');
-  const allFiles = ['./test/setup/browser.js'].concat(testFiles);
-
-  // Lets us differentiate between the first build and subsequent builds
-  var firstBuild = true;
-
-  // This empty stream might seem like a hack, but we need to specify all of our files through
-  // the `entry` option of webpack. Otherwise, it ignores whatever file(s) are placed in here.
-  return gulp.src('')
-    .pipe($.plumber())
-    .pipe(webpackStream({
-      watch: true,
-      entry: allFiles,
-      output: {
-        filename: '__spec-build.js'
-      },
-      module: {
-        loaders: [
-          // This is what allows us to author in future JavaScript
-          {test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader'},
-          // This allows the test setup scripts to load `package.json`
-          {test: /\.json$/, exclude: /node_modules/, loader: 'json-loader'}
-        ]
-      },
-      plugins: [
-        // By default, webpack does `n=>n` compilation with entry files. This concatenates
-        // them into a single chunk.
-        new webpack.optimize.LimitChunkCountPlugin({maxChunks: 1})
-      ],
-      devtool: 'inline-source-map'
-    }, null, () => {
-      if (firstBuild) {
-        $.livereload.listen({port: 35729, host: 'localhost', start: true});
-        $.watch(watchFiles, lintJs);
-      } else {
-        $.livereload.reload('./tmp/__spec-build.js');
-      }
-      firstBuild = false;
-    }))
-    .pipe(gulp.dest('./tmp'));
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,8 +1,8 @@
 const gulp = require('gulp');
 const {cleanDist, cleanTmp} = require('./gulp/clean');
 const {lintJs, lintCss} = require('./gulp/lint');
-const {buildCss, buildJavaScript, build, work} = require('./gulp/build');
-const {test, coverage, watchTests, testBrowser} = require('./gulp/test');
+const {buildCss, build, work} = require('./gulp/build');
+const {test, coverage, watchTests} = require('./gulp/test');
 
 gulp.task('clean', cleanDist);
 gulp.task('clean-tmp', cleanTmp);
@@ -14,7 +14,6 @@ gulp.task('lint', ['lint-js', 'lint-css']);
 // Build a production version of the application
 gulp.task('build', build);
 gulp.task('build-css', buildCss);
-gulp.task('build-javascript', buildJavaScript);
 
 // Set up the application to be developed
 gulp.task('work', work);
@@ -25,7 +24,6 @@ gulp.task('test', ['lint'], test);
 gulp.task('watch-tests', ['lint'], watchTests);
 // Generate a coverage report
 gulp.task('coverage', ['lint'], coverage);
-// Set up a livereload environment for our spec runner `test/runner.html`
-gulp.task('test-browser', ['lint', 'clean-tmp'], testBrowser);
+gulp.task('pre-test-browser', ['lint', 'clean-tmp']);
 
 gulp.task('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "scripts": {
     "test": "gulp test",
     "lint": "gulp lint",
-    "test-browser": "gulp test-browser",
+    "test-browser": "gulp pre-test-browser && BROWSER_TESTING=true webpack -p --bail",
     "watch-tests": "gulp watch-tests",
-    "build": "gulp build",
+    "build": "gulp build && webpack -p --bail",
+    "analyze-build": "NODE_ENV=production ANALYZE_BUILD=true webpack -p --bail",
     "coverage": "BABEL_ENV=tests gulp coverage",
     "work": "gulp work",
     "reset-database": "pls reset-database",
@@ -87,8 +88,8 @@
     "sinon-chai": "2.8.0",
     "stylelint": "7.3.1",
     "supertest": "2.0.0",
-    "webpack": "1.13.2",
-    "webpack-stream": "3.2.0"
+    "webpack": "2.3.2",
+    "webpack-bundle-analyzer": "2.3.1"
   },
   "babelBoilerplateOptions": {
     "entryFileName": "index",

--- a/test/setup/.globals.json
+++ b/test/setup/.globals.json
@@ -7,6 +7,7 @@
     "stub": true,
     "useFakeServer": true,
     "useFakeTimers": true,
-    "useFakeXMLHttpRequest": true
+    "useFakeXMLHttpRequest": true,
+    "addEventListener": true
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const webpack = require('webpack');
+const path = require('path');
+const glob = require('glob');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
+const local = path.join.bind(path, __dirname);
+const isProduction = process.env.NODE_ENV === 'production';
+const isBuildingForTests = process.env.BROWSER_TESTING === 'true';
+
+const plugins = [
+  process.env.ANALYZE_BUILD && new BundleAnalyzerPlugin(),
+
+  // In production set the 'NODE_ENV' value to 'production'.
+  isProduction && new webpack.DefinePlugin({
+    'process.env': {
+      NODE_ENV: JSON.stringify('production')
+    }
+  }),
+
+  // Minify the source code in production.
+  isProduction && new webpack.optimize.UglifyJsPlugin({
+    sourceMap: true,
+    output: {
+      comments: false
+    },
+    compress: {
+      warnings: false,
+      screw_ie8: true
+    }
+  }),
+
+  isBuildingForTests && new webpack.optimize.LimitChunkCountPlugin({
+    maxChunks: 1
+  }),
+].filter(Boolean);
+
+const testFiles = glob.sync('./test/unit/client/**/*.js');
+const allTestFiles = ['./test/setup/browser.js'].concat(testFiles);
+const externals = isBuildingForTests ? {
+  cheerio: 'window',
+  'react/addons': true,
+  'react/lib/ExecutionEnvironment': true,
+  'react/lib/ReactContext': true
+} : {};
+
+const babelLoaderOptions = isBuildingForTests ? {
+  plugins: 'babel-plugin-rewire'
+} : {};
+
+module.exports = {
+  devtool: isProduction ? 'source-map' : 'eval-source-map',
+  plugins,
+  externals,
+
+  entry: {
+    app: isBuildingForTests ? allTestFiles : './client-src/index'
+  },
+
+  output: {
+    path: isBuildingForTests ? local('./tmp') : local('./client-dist'),
+    filename: isBuildingForTests ? '__spec-build.js' : 'app.js',
+  },
+
+  module: {
+    rules: [{
+      test: /\.js$/,
+      exclude: /node_modules/,
+      loader: 'babel-loader',
+      options: babelLoaderOptions
+    }]
+  },
+};


### PR DESCRIPTION
Also fixes the browser test build

Resolves #707 
Resolves #706 
Resolves #705

This also adds in webpack-bundle-analyzer for the heck of it.

---

The one missing component here is the `npm run work` command. Previously, a webpack-stream-based watcher would start that would refresh the app on css or js changes. Now that two processes are required to build (gulp for css, web pack for js), I'll need to figure that out.

Maybe that fancy thing @tbranyen created that lets you fork processes like this could be used here... 