### PR TITLE
Generalize state of categories/transactions

### DIFF
--- a/client/categories/components/categories-list.js
+++ b/client/categories/components/categories-list.js
@@ -185,8 +185,8 @@ export class CategoriesList extends Component {
 function mapStateToProps(state) {
   return {
     isOnline: state.connection,
-    categories: state.categories.categories,
-    categoriesMeta: state.categories.categoriesMeta
+    categories: state.categories.resources,
+    categoriesMeta: state.categories.resourcesMeta
   };
 }
 

--- a/client/categories/components/content.js
+++ b/client/categories/components/content.js
@@ -49,7 +49,7 @@ export class Content extends Component {
 
 function mapStateToProps(state) {
   return {
-    categories: state.categories.categories,
+    categories: state.categories.resources,
     retrievingCategoriesStatus: state.categories.retrievingCategoriesStatus
   };
 }

--- a/client/categories/components/subheader.js
+++ b/client/categories/components/subheader.js
@@ -94,7 +94,7 @@ export class CategoriesSubheader extends Component {
 function mapStateToProps(state) {
   return {
     isOnline: state.connection,
-    categories: state.categories.categories,
+    categories: state.categories.resources,
     creatingCategoryStatus: state.categories.creatingCategoryStatus
   };
 }

--- a/client/state/categories/action-creators.js
+++ b/client/state/categories/action-creators.js
@@ -104,7 +104,7 @@ export function updateCategory(resource) {
   return (dispatch, getState) => {
     const {id} = resource;
 
-    const resourceList = getState().categories.categories;
+    const resourceList = getState().categories.resources;
     const resourceToUpdate = _.find(resourceList, {id});
 
     dispatch({
@@ -153,7 +153,7 @@ export function updateCategory(resource) {
 
 export function deleteCategory(categoryId) {
   return (dispatch, getState) => {
-    const resourceList = getState().categories.categories;
+    const resourceList = getState().categories.resources;
     const resourceToDelete = _.find(resourceList, {id: categoryId});
 
     dispatch({

--- a/client/state/categories/initial-state.js
+++ b/client/state/categories/initial-state.js
@@ -1,6 +1,6 @@
 export default {
-  categories: [],
-  categoriesMeta: [],
+  resources: [],
+  resourcesMeta: [],
   creatingCategoryStatus: null,
   retrievingCategoriesStatus: null
 };

--- a/client/state/categories/reducer.js
+++ b/client/state/categories/reducer.js
@@ -18,10 +18,10 @@ export default (state = initialState, action) => {
     }
 
     case actionTypes.CREATE_CATEGORY_SUCCESS: {
-      let categories = [...state.categories];
-      categories.push(action.resource);
-      const categoriesMeta = [
-        ...state.categoriesMeta,
+      let resources = [...state.resources];
+      resources.push(action.resource);
+      const resourcesMeta = [
+        ...state.resourcesMeta,
         {
           id: action.resource.id,
           ...initialResourceMetaState
@@ -30,8 +30,8 @@ export default (state = initialState, action) => {
       return {
         ...state,
         creatingCategoryStatus: 'SUCCESS',
-        categories,
-        categoriesMeta
+        resources,
+        resourcesMeta
       };
     }
 
@@ -59,7 +59,7 @@ export default (state = initialState, action) => {
     }
 
     case actionTypes.RETRIEVE_CATEGORIES_SUCCESS: {
-      const categoriesMeta = action.resources.map(c => {
+      const resourcesMeta = action.resources.map(c => {
         return {
           id: c.id,
           ...initialResourceMetaState
@@ -69,8 +69,8 @@ export default (state = initialState, action) => {
       return {
         ...state,
         retrievingCategoriesStatus: 'SUCCESS',
-        categories: [...action.resources],
-        categoriesMeta
+        resources: [...action.resources],
+        resourcesMeta
       };
     }
 
@@ -91,7 +91,7 @@ export default (state = initialState, action) => {
 
     // Update category
     case actionTypes.UPDATE_CATEGORY: {
-      const categoriesMeta = state.categoriesMeta.map(c => {
+      const resourcesMeta = state.resourcesMeta.map(c => {
         if (c.id !== action.resource.id) {
           return {...c};
         } else {
@@ -104,14 +104,14 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        categoriesMeta
+        resourcesMeta
       };
     }
 
     case actionTypes.UPDATE_CATEGORY_SUCCESS: {
       let id = action.resource.id;
 
-      let categories = state.categories.map(c => {
+      let resources = state.resources.map(c => {
         if (c.id !== id) {
           return {...c};
         } else {
@@ -119,7 +119,7 @@ export default (state = initialState, action) => {
         }
       });
 
-      const categoriesMeta = state.categoriesMeta.map(c => {
+      const resourcesMeta = state.resourcesMeta.map(c => {
         if (c.id !== id) {
           return {...c};
         } else {
@@ -132,13 +132,13 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        categories,
-        categoriesMeta
+        resources,
+        resourcesMeta
       };
     }
 
     case actionTypes.UPDATE_CATEGORY_FAILURE: {
-      const categoriesMeta = state.categoriesMeta.map(c => {
+      const resourcesMeta = state.resourcesMeta.map(c => {
         if (c.id !== action.resource.id) {
           return {...c};
         } else {
@@ -151,15 +151,15 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        categoriesMeta
+        resourcesMeta
       };
     }
 
     case actionTypes.UPDATE_CATEGORY_ABORTED:
     case actionTypes.UPDATE_CATEGORY_RESET_RESOLUTION: {
       const id = action.resource ? action.resource.id : action.resourceId;
-      const clonedMeta = _.cloneDeep(state.categoriesMeta);
-      const categoriesMeta = clonedMeta.map(c => {
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
+      const resourcesMeta = clonedMeta.map(c => {
         if (c.id !== id) {
           return {...c};
         } else {
@@ -172,14 +172,14 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        categoriesMeta
+        resourcesMeta
       };
     }
 
     // Delete category
     case actionTypes.DELETE_CATEGORY: {
-      const clonedMeta = _.cloneDeep(state.categoriesMeta);
-      const categoriesMeta = clonedMeta.map(c => {
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
+      const resourcesMeta = clonedMeta.map(c => {
         if (c.id !== action.resource.id) {
           return c;
         } else {
@@ -192,28 +192,28 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        categoriesMeta
+        resourcesMeta
       };
     }
 
     case actionTypes.DELETE_CATEGORY_SUCCESS: {
       const rejectionFn = val => val.id === action.resource.id;
-      const clonedCategories = _.cloneDeep(state.categories);
-      const clonedMeta = _.cloneDeep(state.categoriesMeta);
+      const clonedResources = _.cloneDeep(state.resources);
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
 
-      let categories = _.reject(clonedCategories, rejectionFn);
-      let categoriesMeta = _.reject(clonedMeta, rejectionFn);
+      let resources = _.reject(clonedResources, rejectionFn);
+      let resourcesMeta = _.reject(clonedMeta, rejectionFn);
       return {
         ...state,
-        categories,
-        categoriesMeta
+        resources,
+        resourcesMeta
       };
     }
 
     case actionTypes.DELETE_CATEGORY_FAILURE:
     case actionTypes.DELETE_CATEGORY_ABORTED: {
-      const clonedMeta = _.cloneDeep(state.categoriesMeta);
-      const categoriesMeta = clonedMeta.map(c => {
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
+      const resourcesMeta = clonedMeta.map(c => {
         if (c.id !== action.resource.id) {
           return c;
         } else {
@@ -226,7 +226,7 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        categoriesMeta
+        resourcesMeta
       };
     }
 

--- a/client/state/transactions/action-creators.js
+++ b/client/state/transactions/action-creators.js
@@ -41,7 +41,7 @@ export function createTransaction(resource) {
         } else {
           dispatch({
             type: actionTypes.CREATE_TRANSACTION_SUCCESS,
-            transaction: JSON.parse(body).data
+            resource: JSON.parse(body).data
           });
         }
       }
@@ -78,7 +78,7 @@ export function retrieveTransactions() {
         } else {
           dispatch({
             type: actionTypes.RETRIEVE_TRANSACTIONS_SUCCESS,
-            transactions: JSON.parse(body).data
+            resources: JSON.parse(body).data
           });
         }
       }
@@ -101,7 +101,7 @@ export function updateTransaction(resource) {
   return (dispatch, getState) => {
     const {id} = resource;
 
-    const resourceList = getState().transactions.transactions;
+    const resourceList = getState().transactions.resources;
     const resourceToUpdate = _.find(resourceList, {id});
 
     dispatch({
@@ -148,7 +148,7 @@ export function updateTransaction(resource) {
 
 export function deleteTransaction(id) {
   return (dispatch, getState) => {
-    const resourceList = getState().transactions.transactions;
+    const resourceList = getState().transactions.resources;
     const resourceToDelete = _.find(resourceList, {id});
 
     dispatch({

--- a/client/state/transactions/initial-state.js
+++ b/client/state/transactions/initial-state.js
@@ -1,6 +1,6 @@
 export default {
-  transactions: [],
-  transactionsMeta: [],
+  resources: [],
+  resourcesMeta: [],
   creatingTransactionStatus: null,
   retrievingTransactionsStatus: null
 };

--- a/client/state/transactions/reducer.js
+++ b/client/state/transactions/reducer.js
@@ -18,20 +18,20 @@ export default (state = initialState, action) => {
     }
 
     case actionTypes.CREATE_TRANSACTION_SUCCESS: {
-      let transactions = [...state.transactions];
-      transactions.push(action.transaction);
-      const transactionsMeta = [
-        ...state.transactionsMeta,
+      let resources = [...state.resources];
+      resources.push(action.resource);
+      const resourcesMeta = [
+        ...state.resourcesMeta,
         {
-          id: action.transaction.id,
+          id: action.resource.id,
           ...initialResourceMetaState
         }
       ];
       return {
         ...state,
         creatingTransactionStatus: 'SUCCESS',
-        transactions,
-        transactionsMeta
+        resources,
+        resourcesMeta
       };
     }
 
@@ -59,7 +59,7 @@ export default (state = initialState, action) => {
     }
 
     case actionTypes.RETRIEVE_TRANSACTIONS_SUCCESS: {
-      const transactionsMeta = action.transactions.map(c => {
+      const resourcesMeta = action.resources.map(c => {
         return {
           id: c.id,
           ...initialResourceMetaState
@@ -69,8 +69,8 @@ export default (state = initialState, action) => {
       return {
         ...state,
         retrievingTransactionsStatus: 'SUCCESS',
-        transactions: [...action.transactions],
-        transactionsMeta
+        resources: [...action.resources],
+        resourcesMeta
       };
     }
 
@@ -91,8 +91,8 @@ export default (state = initialState, action) => {
 
     // Update transaction
     case actionTypes.UPDATE_TRANSACTION: {
-      const transactionsMeta = state.transactionsMeta.map(c => {
-        if (c.id !== action.transactionId) {
+      const resourcesMeta = state.resourcesMeta.map(c => {
+        if (c.id !== action.resource.id) {
           return {...c};
         } else {
           return {
@@ -104,22 +104,22 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        transactionsMeta
+        resourcesMeta
       };
     }
 
     case actionTypes.UPDATE_TRANSACTION_SUCCESS: {
-      let id = action.transaction.id;
+      let id = action.resource.id;
 
-      let transactions = state.transactions.map(c => {
+      let resources = state.resources.map(c => {
         if (c.id !== id) {
           return {...c};
         } else {
-          return {...action.transaction};
+          return {...action.resource};
         }
       });
 
-      const transactionsMeta = state.transactionsMeta.map(c => {
+      const resourcesMeta = state.resourcesMeta.map(c => {
         if (c.id !== id) {
           return {...c};
         } else {
@@ -132,14 +132,14 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        transactions,
-        transactionsMeta
+        resources,
+        resourcesMeta
       };
     }
 
     case actionTypes.UPDATE_TRANSACTION_FAILURE: {
-      const transactionsMeta = state.transactionsMeta.map(c => {
-        if (c.id !== action.transactionId) {
+      const resourcesMeta = state.resourcesMeta.map(c => {
+        if (c.id !== action.resource.id) {
           return {...c};
         } else {
           return {
@@ -151,15 +151,15 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        transactionsMeta
+        resourcesMeta
       };
     }
 
     case actionTypes.UPDATE_TRANSACTION_ABORTED:
     case actionTypes.UPDATE_TRANSACTION_RESET_RESOLUTION: {
-      const clonedMeta = _.cloneDeep(state.transactionsMeta);
-      const transactionsMeta = clonedMeta.map(c => {
-        if (c.id !== action.transactionId) {
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
+      const resourcesMeta = clonedMeta.map(c => {
+        if (c.id !== action.resource.id) {
           return {...c};
         } else {
           return {
@@ -171,14 +171,14 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        transactionsMeta
+        resourcesMeta
       };
     }
 
     // Delete transaction
     case actionTypes.DELETE_TRANSACTION: {
-      const clonedMeta = _.cloneDeep(state.transactionsMeta);
-      const transactionsMeta = clonedMeta.map(c => {
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
+      const resourcesMeta = clonedMeta.map(c => {
         if (c.id !== action.resource.id) {
           return c;
         } else {
@@ -191,28 +191,28 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        transactionsMeta
+        resourcesMeta
       };
     }
 
     case actionTypes.DELETE_TRANSACTION_SUCCESS: {
       const rejectionFn = val => val.id === action.resource.id;
-      const clonedTransactions = _.cloneDeep(state.transactions);
-      const clonedMeta = _.cloneDeep(state.transactionsMeta);
+      const clonedResources = _.cloneDeep(state.resources);
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
 
-      let transactions = _.reject(clonedTransactions, rejectionFn);
-      let transactionsMeta = _.reject(clonedMeta, rejectionFn);
+      let resources = _.reject(clonedResources, rejectionFn);
+      let resourcesMeta = _.reject(clonedMeta, rejectionFn);
       return {
         ...state,
-        transactions,
-        transactionsMeta
+        resources,
+        resourcesMeta
       };
     }
 
     case actionTypes.DELETE_TRANSACTION_FAILURE:
     case actionTypes.DELETE_TRANSACTION_ABORTED: {
-      const clonedMeta = _.cloneDeep(state.transactionsMeta);
-      const transactionsMeta = clonedMeta.map(c => {
+      const clonedMeta = _.cloneDeep(state.resourcesMeta);
+      const resourcesMeta = clonedMeta.map(c => {
         if (c.id !== action.resource.id) {
           return c;
         } else {
@@ -225,7 +225,7 @@ export default (state = initialState, action) => {
 
       return {
         ...state,
-        transactionsMeta
+        resourcesMeta
       };
     }
 

--- a/client/transactions/components/content.js
+++ b/client/transactions/components/content.js
@@ -105,7 +105,7 @@ export class Content extends Component {
 
 function mapStateToProps(state) {
   return {
-    transactions: state.transactions.transactions,
+    transactions: state.transactions.resources,
     retrievingTransactionsStatus: state.transactions.retrievingTransactionsStatus,
     retrievingCategoriesStatus: state.categories.retrievingCategoriesStatus,
   };

--- a/client/transactions/components/transactions-list.js
+++ b/client/transactions/components/transactions-list.js
@@ -118,7 +118,7 @@ export class TransactionsList extends Component {
 function mapStateToProps(state) {
   return {
     isOnline: state.connection,
-    transactionsMeta: state.transactions.transactionsMeta
+    transactionsMeta: state.transactions.resourcesMeta
   };
 }
 

--- a/test/unit/client/categories/components/categories-list.js
+++ b/test/unit/client/categories/components/categories-list.js
@@ -16,8 +16,8 @@ describe('CategoriesList', function() {
       expect(mapStateToProps({
         connection: true,
         categories: {
-          categories: [1, 2, 3],
-          categoriesMeta: 'hello'
+          resources: [1, 2, 3],
+          resourcesMeta: 'hello'
         },
         transactions: {},
         oink: true

--- a/test/unit/client/categories/components/content.js
+++ b/test/unit/client/categories/components/content.js
@@ -17,7 +17,7 @@ describe('CategoriesContent', function() {
     it('returns the right props', () => {
       expect(mapStateToProps({
         categories: {
-          categories: [1, 2, 3],
+          resources: [1, 2, 3],
           retrievingCategoriesStatus: 'hello'
         },
         transactions: {},

--- a/test/unit/client/categories/components/subheader.js
+++ b/test/unit/client/categories/components/subheader.js
@@ -13,7 +13,7 @@ describe('CategoriesSubheader', function() {
       expect(mapStateToProps({
         connection: true,
         categories: {
-          categories: [1, 2, 3],
+          resources: [1, 2, 3],
           creatingCategoryStatus: 'hello'
         },
         transactions: {},

--- a/test/unit/client/state/categories/action-creators.js
+++ b/test/unit/client/state/categories/action-creators.js
@@ -226,7 +226,7 @@ describe('categories/actionCreators', function() {
       this.getState = function() {
         return {
           categories: {
-            categories: [
+            resources: [
               {id: 2, type: 'categories', attributes: {label: 'pizza'}},
               {id: 10, type: 'categories', attributes: {label: 'what'}}
             ]
@@ -345,7 +345,7 @@ describe('categories/actionCreators', function() {
       this.getState = function() {
         return {
           categories: {
-            categories: [
+            resources: [
               {id: 2, type: 'categories', attributes: {label: 'pizza'}},
               {id: 10, type: 'categories', attributes: {label: 'what'}}
             ]

--- a/test/unit/client/state/categories/reducer.js
+++ b/test/unit/client/state/categories/reducer.js
@@ -12,14 +12,14 @@ describe('categories/reducer', function() {
   describe('CREATE_CATEGORY', () => {
     it('should return a new state with `creatingCategoryStatus` set to PENDING', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: null
       };
       const action = {type: actionTypes.CREATE_CATEGORY};
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'PENDING'
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -29,8 +29,8 @@ describe('categories/reducer', function() {
   describe('CREATE_CATEGORY_SUCCESS', () => {
     it('should return a new state with `creatingCategoryStatus` set to SUCCESS and the category', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.CREATE_CATEGORY_SUCCESS,
@@ -40,13 +40,13 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [
+        resources: [
           {id: 1},
           {id: 2},
           {id: 3},
           {id: 4, pasta: 'yum'}
         ],
-        categoriesMeta: [
+        resourcesMeta: [
           {id: 1},
           {id: 2},
           {id: 3},
@@ -61,8 +61,8 @@ describe('categories/reducer', function() {
   describe('CREATE_CATEGORY_FAILURE', () => {
     it('should return a new state with `creatingCategoryStatus` set to FAILURE', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'PENDING'
       };
       const action = {
@@ -73,8 +73,8 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'FAILURE'
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -84,8 +84,8 @@ describe('categories/reducer', function() {
   describe('CREATE_CATEGORY_ABORTED', () => {
     it('should return a new state with `creatingCategoryStatus` set to null', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'PENDING'
       };
       const action = {
@@ -96,8 +96,8 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: null
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -107,14 +107,14 @@ describe('categories/reducer', function() {
   describe('CREATE_CATEGORY_RESET_RESOLUTION', () => {
     it('should return a new state with `creatingCategoryStatus` set to null', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: 'PENDING'
       };
       const action = {type: actionTypes.CREATE_CATEGORY_RESET_RESOLUTION};
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingCategoryStatus: null
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -142,8 +142,8 @@ describe('categories/reducer', function() {
       };
       var newState = {
         oink: true,
-        categories: [{id: 2, name: 'pizza'}, {id: 5, name: 'sandwich'}],
-        categoriesMeta: [
+        resources: [{id: 2, name: 'pizza'}, {id: 5, name: 'sandwich'}],
+        resourcesMeta: [
           {id: 2, updatingStatus: null, isDeleting: false},
           {id: 5, updatingStatus: null, isDeleting: false}
         ],
@@ -192,8 +192,8 @@ describe('categories/reducer', function() {
   describe('UPDATE_CATEGORY', () => {
     it('should return a new state with `updatingStatus` set to PENDING for that category', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY,
@@ -202,8 +202,8 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'PENDING'},
           {id: 3}
@@ -216,8 +216,8 @@ describe('categories/reducer', function() {
   describe('UPDATE_CATEGORY_SUCCESS', () => {
     it('should return a new state with `updatingStatus` set to SUCCESS for that category', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY_SUCCESS,
@@ -227,12 +227,12 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [
+        resources: [
           {id: 1},
           {id: 2, pasta: 'yum'},
           {id: 3}
         ],
-        categoriesMeta: [
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'SUCCESS'},
           {id: 3}
@@ -245,8 +245,8 @@ describe('categories/reducer', function() {
   describe('UPDATE_CATEGORY_FAILURE', () => {
     it('should return a new state with `updatingStatus` set to FAILURE for that category', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.UPDATE_CATEGORY_FAILURE,
@@ -255,8 +255,8 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'FAILURE'},
           {id: 3}
@@ -269,8 +269,8 @@ describe('categories/reducer', function() {
   describe('UPDATE_CATEGORY_ABORTED', () => {
     it('should return a new state with `updatingStatus` set to `null` for that category', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'FAILURE'},
           {id: 3}
@@ -283,8 +283,8 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: null},
           {id: 3}
@@ -297,8 +297,8 @@ describe('categories/reducer', function() {
   describe('UPDATE_CATEGORY_RESET_RESOLUTION', () => {
     it('should return a new state with `updatingStatus` set to `null` for that category', () => {
       const state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'FAILURE'},
           {id: 3}
@@ -311,8 +311,8 @@ describe('categories/reducer', function() {
         }
       };
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: null},
           {id: 3}
@@ -326,8 +326,8 @@ describe('categories/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_CATEGORY,
@@ -339,8 +339,8 @@ describe('categories/reducer', function() {
 
     it('should return a new state with `isDeleting` set to true for that category', () => {
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, isDeleting: true},
           {id: 3}
@@ -354,8 +354,8 @@ describe('categories/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_CATEGORY_SUCCESS,
@@ -367,8 +367,8 @@ describe('categories/reducer', function() {
 
     it('should return a new state without the category in categories', () => {
       var newState = {
-        categories: [{id: 1}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 3}]
+        resources: [{id: 1}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 3}]
       };
       expect(reducer(state, action)).to.deep.equal(newState);
     });
@@ -378,8 +378,8 @@ describe('categories/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_CATEGORY_FAILURE,
@@ -391,8 +391,8 @@ describe('categories/reducer', function() {
 
     it('should return a new state with `isDeleting` set to false for that category', () => {
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, isDeleting: false},
           {id: 3}
@@ -406,8 +406,8 @@ describe('categories/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_CATEGORY_FAILURE,
@@ -419,8 +419,8 @@ describe('categories/reducer', function() {
 
     it('should return a new state with `isDeleting` set to false for that category', () => {
       var newState = {
-        categories: [{id: 1}, {id: 2}, {id: 3}],
-        categoriesMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, isDeleting: false},
           {id: 3}

--- a/test/unit/client/state/transactions/action-creators.js
+++ b/test/unit/client/state/transactions/action-creators.js
@@ -70,7 +70,7 @@ describe('transactions/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.CREATE_TRANSACTION_SUCCESS,
-        transaction: {
+        resource: {
           id: 10,
           attributes: {
             label: 'pizza'
@@ -114,7 +114,7 @@ describe('transactions/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.CREATE_TRANSACTION_SUCCESS,
-        transaction: {
+        resource: {
           type: 'transactions',
           attributes: {
             label: 'pizza'
@@ -174,7 +174,7 @@ describe('transactions/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.RETRIEVE_TRANSACTIONS_SUCCESS,
-        transactions: [
+        resources: [
           {id: 1},
           {id: 2}
         ]
@@ -204,7 +204,7 @@ describe('transactions/actionCreators', function() {
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.RETRIEVE_TRANSACTIONS_SUCCESS,
-        transactions: undefined
+        resources: undefined
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.RETRIEVE_TRANSACTIONS_FAILURE
@@ -227,7 +227,7 @@ describe('transactions/actionCreators', function() {
       this.getState = function() {
         return {
           transactions: {
-            transactions: [
+            resources: [
               {id: 2, type: 'transactions', attributes: {label: 'pizza'}},
               {id: 10, type: 'transactions', attributes: {label: 'what'}}
             ]
@@ -365,7 +365,7 @@ describe('transactions/actionCreators', function() {
       this.getState = function() {
         return {
           transactions: {
-            transactions: [
+            resources: [
               {id: 2, type: 'transactions', attributes: {label: 'pizza'}},
               {id: 10, type: 'transactions', attributes: {label: 'what'}}
             ]

--- a/test/unit/client/state/transactions/reducer.js
+++ b/test/unit/client/state/transactions/reducer.js
@@ -12,14 +12,14 @@ describe('transactions/reducer', function() {
   describe('CREATE_TRANSACTION', () => {
     it('should return a new state with `creatingTransactionStatus` set to PENDING', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: null
       };
       const action = {type: actionTypes.CREATE_TRANSACTION};
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: 'PENDING'
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -29,24 +29,24 @@ describe('transactions/reducer', function() {
   describe('CREATE_TRANSACTION_SUCCESS', () => {
     it('should return a new state with `creatingTransactionStatus` set to SUCCESS and the transaction', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.CREATE_TRANSACTION_SUCCESS,
-        transaction: {
+        resource: {
           id: 4,
           pasta: 'yum'
         }
       };
       var newState = {
-        transactions: [
+        resources: [
           {id: 1},
           {id: 2},
           {id: 3},
           {id: 4, pasta: 'yum'}
         ],
-        transactionsMeta: [
+        resourcesMeta: [
           {id: 1},
           {id: 2},
           {id: 3},
@@ -61,14 +61,14 @@ describe('transactions/reducer', function() {
   describe('CREATE_TRANSACTION_FAILURE', () => {
     it('should return a new state with `creatingTransactionStatus` set to FAILURE', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: 'PENDING'
       };
       const action = {type: actionTypes.CREATE_TRANSACTION_FAILURE};
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: 'FAILURE'
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -78,14 +78,14 @@ describe('transactions/reducer', function() {
   describe('CREATE_TRANSACTION_ABORTED', () => {
     it('should return a new state with `creatingTransactionStatus` set to null', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: 'PENDING'
       };
       const action = {type: actionTypes.CREATE_TRANSACTION_ABORTED};
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: null
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -95,14 +95,14 @@ describe('transactions/reducer', function() {
   describe('CREATE_TRANSACTION_RESET_RESOLUTION', () => {
     it('should return a new state with `creatingTransactionStatus` set to null', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: 'PENDING'
       };
       const action = {type: actionTypes.CREATE_TRANSACTION_RESET_RESOLUTION};
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}],
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}],
         creatingTransactionStatus: null
       };
       expect(reducer(state, action)).to.deep.equal(newState);
@@ -126,12 +126,12 @@ describe('transactions/reducer', function() {
       const state = {oink: true};
       const action = {
         type: actionTypes.RETRIEVE_TRANSACTIONS_SUCCESS,
-        transactions: [{id: 2, name: 'pizza'}, {id: 5, name: 'sandwich'}]
+        resources: [{id: 2, name: 'pizza'}, {id: 5, name: 'sandwich'}]
       };
       var newState = {
         oink: true,
-        transactions: [{id: 2, name: 'pizza'}, {id: 5, name: 'sandwich'}],
-        transactionsMeta: [
+        resources: [{id: 2, name: 'pizza'}, {id: 5, name: 'sandwich'}],
+        resourcesMeta: [
           {id: 2, updatingStatus: null, isDeleting: false},
           {id: 5, updatingStatus: null, isDeleting: false}
         ],
@@ -180,16 +180,16 @@ describe('transactions/reducer', function() {
   describe('UPDATE_TRANSACTION', () => {
     it('should return a new state with `updatingStatus` set to PENDING for that transaction', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.UPDATE_TRANSACTION,
-        transactionId: 2
+        resource: {id: 2}
       };
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'PENDING'},
           {id: 3}
@@ -202,23 +202,23 @@ describe('transactions/reducer', function() {
   describe('UPDATE_TRANSACTION_SUCCESS', () => {
     it('should return a new state with `updatingStatus` set to SUCCESS for that transaction', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.UPDATE_TRANSACTION_SUCCESS,
-        transaction: {
+        resource: {
           id: 2,
           pasta: 'yum'
         }
       };
       var newState = {
-        transactions: [
+        resources: [
           {id: 1},
           {id: 2, pasta: 'yum'},
           {id: 3}
         ],
-        transactionsMeta: [
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'SUCCESS'},
           {id: 3}
@@ -231,16 +231,16 @@ describe('transactions/reducer', function() {
   describe('UPDATE_TRANSACTION_FAILURE', () => {
     it('should return a new state with `updatingStatus` set to FAILURE for that transaction', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       const action = {
         type: actionTypes.UPDATE_TRANSACTION_FAILURE,
-        transactionId: 2
+        resource: {id: 2}
       };
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'FAILURE'},
           {id: 3}
@@ -253,8 +253,8 @@ describe('transactions/reducer', function() {
   describe('UPDATE_TRANSACTION_ABORTED', () => {
     it('should return a new state with `updatingStatus` set to `null` for that transaction', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'FAILURE'},
           {id: 3}
@@ -262,11 +262,11 @@ describe('transactions/reducer', function() {
       };
       const action = {
         type: actionTypes.UPDATE_TRANSACTION_ABORTED,
-        transactionId: 2
+        resource: {id: 2}
       };
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: null},
           {id: 3}
@@ -279,8 +279,8 @@ describe('transactions/reducer', function() {
   describe('UPDATE_TRANSACTION_RESET_RESOLUTION', () => {
     it('should return a new state with `updatingStatus` set to `null` for that transaction', () => {
       const state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: 'FAILURE'},
           {id: 3}
@@ -288,11 +288,11 @@ describe('transactions/reducer', function() {
       };
       const action = {
         type: actionTypes.UPDATE_TRANSACTION_RESET_RESOLUTION,
-        transactionId: 2
+        resource: {id: 2}
       };
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, updatingStatus: null},
           {id: 3}
@@ -306,8 +306,8 @@ describe('transactions/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_TRANSACTION,
@@ -317,8 +317,8 @@ describe('transactions/reducer', function() {
 
     it('should return a new state with `isDeleting` set to true for that transaction', () => {
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, isDeleting: true},
           {id: 3}
@@ -332,8 +332,8 @@ describe('transactions/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_TRANSACTION_SUCCESS,
@@ -343,8 +343,8 @@ describe('transactions/reducer', function() {
 
     it('should return a new state without the transaction in transactions', () => {
       var newState = {
-        transactions: [{id: 1}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 3}]
+        resources: [{id: 1}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 3}]
       };
       expect(reducer(state, action)).to.deep.equal(newState);
     });
@@ -354,8 +354,8 @@ describe('transactions/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_TRANSACTION_FAILURE,
@@ -365,8 +365,8 @@ describe('transactions/reducer', function() {
 
     it('should return a new state with `isDeleting` set to false for that transaction', () => {
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, isDeleting: false},
           {id: 3}
@@ -380,8 +380,8 @@ describe('transactions/reducer', function() {
     let state, action;
     beforeEach(() => {
       state = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [{id: 1}, {id: 2}, {id: 3}]
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [{id: 1}, {id: 2}, {id: 3}]
       };
       action = {
         type: actionTypes.DELETE_TRANSACTION_FAILURE,
@@ -391,8 +391,8 @@ describe('transactions/reducer', function() {
 
     it('should return a new state with `isDeleting` set to false for that transaction', () => {
       var newState = {
-        transactions: [{id: 1}, {id: 2}, {id: 3}],
-        transactionsMeta: [
+        resources: [{id: 1}, {id: 2}, {id: 3}],
+        resourcesMeta: [
           {id: 1},
           {id: 2, isDeleting: false},
           {id: 3}


### PR DESCRIPTION
This makes the handling of resources in the state more generic, like what you might find in redux-simple-resource. Another 💯 idea by @sprjr

There's more to be done:

1. make meta an object
2. make the list have a meta, rather than making it flat on the slice's root
3. update to use a single action creator for all resources, since JSON API supports dat

---

As part of #734 