### PR TITLE
Add ownership to categories and transactions

### DIFF
--- a/client/state/categories/action-creators.js
+++ b/client/state/categories/action-creators.js
@@ -10,9 +10,10 @@ export function resetCreateCategoryResolution() {
 }
 
 export function createCategory(resource) {
-  resource.type = 'categories';
-
-  return dispatch => {
+  return (dispatch, getState) => {
+    const userId = getState().auth.user.id;
+    resource.attributes.user = userId;
+    resource.type = 'categories';
     dispatch({
       type: actionTypes.CREATE_CATEGORY,
       resource
@@ -61,11 +62,13 @@ export function resetRetrieveCategoriesResolution() {
 }
 
 export function retrieveCategories() {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const {auth} = getState();
+    const userId = auth.user.id;
     dispatch({type: actionTypes.RETRIEVE_CATEGORIES});
 
     const req = xhr.get(
-      '/api/categories',
+      `/api/categories?filter[user]=${userId}`,
       {
         headers: {
           'Content-Type': 'application/vnd.api+json'

--- a/client/state/transactions/action-creators.js
+++ b/client/state/transactions/action-creators.js
@@ -10,9 +10,11 @@ export function resetCreateTransactionResolution() {
 }
 
 export function createTransaction(resource) {
-  resource.type = 'transactions';
+  return (dispatch, getState) => {
+    const userId = getState().auth.user.id;
+    resource.attributes.user = userId;
+    resource.type = 'transactions';
 
-  return dispatch => {
     dispatch({
       type: actionTypes.CREATE_TRANSACTION,
       resource
@@ -58,11 +60,13 @@ export function resetRetrieveTransactionsResolution() {
 }
 
 export function retrieveTransactions() {
-  return (dispatch) => {
+  return (dispatch, getState) => {
+    const {auth} = getState();
+    const userId = auth.user.id;
     dispatch({type: actionTypes.RETRIEVE_TRANSACTIONS});
 
     const req = xhr.get(
-      '/api/transactions',
+      `/api/transactions?filter[user]=${userId}`,
       {
         headers: {
           'Content-Type': 'application/vnd.api+json'

--- a/server/store.js
+++ b/server/store.js
@@ -9,14 +9,14 @@ const resources = {
     label: String,
     emoji: String,
     transactions: [Array('transaction'), 'category'],
-    user: ['user_account']
+    user: 'user_account'
   },
   transaction: {
     description: String,
     value: Number,
     date: String,
     category: ['category', 'transactions'],
-    user: ['user_account']
+    user: 'user_account'
   },
   user_account: {
     google_id: String

--- a/test/unit/client/state/categories/action-creators.js
+++ b/test/unit/client/state/categories/action-creators.js
@@ -22,15 +22,37 @@ describe('categories/actionCreators', function() {
   });
 
   describe('createCategory', () => {
+    beforeEach(() => {
+      this.getState = function() {
+        return {
+          auth: {
+            user: {
+              id: 100
+            }
+          },
+          categories: {
+            resources: [
+              {id: 2, type: 'categories', attributes: {label: 'pizza'}},
+              {id: 10, type: 'categories', attributes: {label: 'what'}}
+            ]
+          }
+        };
+      };
+    });
+
+    afterEach(() => {
+      this.getState = null;
+    });
+
     it('should dispatch a begin action before making the request', () => {
       const thunk = actionCreators.createCategory({attributes: {label: 'pizza'}});
-      thunk(this.dispatch);
+      thunk(this.dispatch, this.getState);
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
         type: actionTypes.CREATE_CATEGORY,
         resource: {
           type: 'categories',
-          attributes: {label: 'pizza'}
+          attributes: {label: 'pizza', user: 100}
         }
       });
       expect(this.dispatch).to.have.been.calledBefore(xhr.post);
@@ -38,14 +60,15 @@ describe('categories/actionCreators', function() {
 
     it('should generate the expected request', () => {
       const thunk = actionCreators.createCategory({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       expect(req).to.be.instanceof(this.FakeXMLHttpRequest);
       expect(req.url).to.equal('/api/categories');
       expect(req.method).to.equal('POST');
       const expectedBody = JSON.stringify({
         data: {
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           },
           type: 'categories',
         }
@@ -55,13 +78,14 @@ describe('categories/actionCreators', function() {
 
     it('should respond appropriately when there are no errors', () => {
       const thunk = actionCreators.createCategory({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       const respBody = JSON.stringify({
         data: {
           id: 10,
           type: 'categories',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -73,7 +97,8 @@ describe('categories/actionCreators', function() {
           id: 10,
           type: 'categories',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -83,7 +108,8 @@ describe('categories/actionCreators', function() {
           id: 10,
           type: 'categories',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -91,42 +117,42 @@ describe('categories/actionCreators', function() {
 
     it('should respond appropriately when aborted', () => {
       const thunk = actionCreators.createCategory({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.abort();
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.CREATE_CATEGORY,
         resource: {
           type: 'categories',
-          attributes: {label: 'pizza'}
+          attributes: {label: 'pizza', user: 100}
         }
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.CREATE_CATEGORY_ABORTED,
         resource: {
           type: 'categories',
-          attributes: {label: 'pizza'}
+          attributes: {label: 'pizza', user: 100}
         }
       });
     });
 
     it('should respond appropriately when a error status code is returned', () => {
       const thunk = actionCreators.createCategory({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.respond(500);
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({
         type: actionTypes.CREATE_CATEGORY_SUCCESS,
         resource: {
           type: 'categories',
-          attributes: {label: 'pizza'}
+          attributes: {label: 'pizza', user: 100}
         }
       });
       expect(this.dispatch).to.have.been.calledWith({
         type: actionTypes.CREATE_CATEGORY_FAILURE,
         resource: {
           type: 'categories',
-          attributes: {label: 'pizza'}
+          attributes: {label: 'pizza', user: 100}
         }
       });
     });
@@ -142,9 +168,31 @@ describe('categories/actionCreators', function() {
   });
 
   describe('retrieveCategories', () => {
+    beforeEach(() => {
+      this.getState = function() {
+        return {
+          auth: {
+            user: {
+              id: 100
+            }
+          },
+          categories: {
+            resources: [
+              {id: 2, type: 'categories', attributes: {label: 'pizza'}},
+              {id: 10, type: 'categories', attributes: {label: 'what'}}
+            ]
+          }
+        };
+      };
+    });
+
+    afterEach(() => {
+      this.getState = null;
+    });
+
     it('should dispatch a begin action before making the request', () => {
       const thunk = actionCreators.retrieveCategories();
-      thunk(this.dispatch);
+      thunk(this.dispatch, this.getState);
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
         type: actionTypes.RETRIEVE_CATEGORIES
@@ -154,15 +202,15 @@ describe('categories/actionCreators', function() {
 
     it('should generate the expected request', () => {
       const thunk = actionCreators.retrieveCategories();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       expect(req).to.be.instanceof(this.FakeXMLHttpRequest);
-      expect(req.url).to.equal('/api/categories');
+      expect(req.url).to.equal('/api/categories?filter[user]=100');
       expect(req.method).to.equal('GET');
     });
 
     it('should respond appropriately when there are no errors', () => {
       const thunk = actionCreators.retrieveCategories();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       const respBody = JSON.stringify({
         data: [
           {id: 1},
@@ -185,7 +233,7 @@ describe('categories/actionCreators', function() {
 
     it('should respond appropriately when aborted', () => {
       const thunk = actionCreators.retrieveCategories();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.abort();
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
@@ -198,7 +246,7 @@ describe('categories/actionCreators', function() {
 
     it('should respond appropriately when a error status code is returned', () => {
       const thunk = actionCreators.retrieveCategories();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.respond(500);
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({

--- a/test/unit/client/state/transactions/action-creators.js
+++ b/test/unit/client/state/transactions/action-creators.js
@@ -22,16 +22,39 @@ describe('transactions/actionCreators', function() {
   });
 
   describe('createTransaction', () => {
+    beforeEach(() => {
+      this.getState = function() {
+        return {
+          auth: {
+            user: {
+              id: 100
+            }
+          },
+          transactions: {
+            resources: [
+              {id: 2, type: 'transactions', attributes: {label: 'pizza'}},
+              {id: 10, type: 'transactions', attributes: {label: 'what'}}
+            ]
+          }
+        };
+      };
+    });
+
+    afterEach(() => {
+      this.getState = null;
+    });
+
     it('should dispatch a begin action before making the request', () => {
       const thunk = actionCreators.createTransaction({attributes: {label: 'pizza'}});
-      thunk(this.dispatch);
+      thunk(this.dispatch, this.getState);
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
         type: actionTypes.CREATE_TRANSACTION,
         resource: {
           type: 'transactions',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -40,14 +63,15 @@ describe('transactions/actionCreators', function() {
 
     it('should generate the expected request', () => {
       const thunk = actionCreators.createTransaction({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       expect(req).to.be.instanceof(this.FakeXMLHttpRequest);
       expect(req.url).to.equal('/api/transactions');
       expect(req.method).to.equal('POST');
       const expectedBody = JSON.stringify({
         data: {
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           },
           type: 'transactions',
         }
@@ -57,12 +81,13 @@ describe('transactions/actionCreators', function() {
 
     it('should respond appropriately when there are no errors', () => {
       const thunk = actionCreators.createTransaction({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       const respBody = JSON.stringify({
         data: {
           id: 10,
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -73,7 +98,8 @@ describe('transactions/actionCreators', function() {
         resource: {
           id: 10,
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -84,7 +110,7 @@ describe('transactions/actionCreators', function() {
 
     it('should respond appropriately when aborted', () => {
       const thunk = actionCreators.createTransaction({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.abort();
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
@@ -92,7 +118,8 @@ describe('transactions/actionCreators', function() {
         resource: {
           type: 'transactions',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -101,7 +128,8 @@ describe('transactions/actionCreators', function() {
         resource: {
           type: 'transactions',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -109,7 +137,7 @@ describe('transactions/actionCreators', function() {
 
     it('should respond appropriately when a error status code is returned', () => {
       const thunk = actionCreators.createTransaction({attributes: {label: 'pizza'}});
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.respond(500);
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({
@@ -117,7 +145,8 @@ describe('transactions/actionCreators', function() {
         resource: {
           type: 'transactions',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -126,7 +155,8 @@ describe('transactions/actionCreators', function() {
         resource: {
           type: 'transactions',
           attributes: {
-            label: 'pizza'
+            label: 'pizza',
+            user: 100
           }
         }
       });
@@ -143,9 +173,31 @@ describe('transactions/actionCreators', function() {
   });
 
   describe('retrieveTransactions', () => {
+    beforeEach(() => {
+      this.getState = function() {
+        return {
+          auth: {
+            user: {
+              id: 100
+            }
+          },
+          transactions: {
+            resources: [
+              {id: 2, type: 'transactions', attributes: {label: 'pizza'}},
+              {id: 10, type: 'transactions', attributes: {label: 'what'}}
+            ]
+          }
+        };
+      };
+    });
+
+    afterEach(() => {
+      this.getState = null;
+    });
+
     it('should dispatch a begin action before making the request', () => {
       const thunk = actionCreators.retrieveTransactions();
-      thunk(this.dispatch);
+      thunk(this.dispatch, this.getState);
       expect(this.dispatch).to.have.been.calledOnce;
       expect(this.dispatch).to.have.been.calledWithExactly({
         type: actionTypes.RETRIEVE_TRANSACTIONS
@@ -155,15 +207,15 @@ describe('transactions/actionCreators', function() {
 
     it('should generate the expected request', () => {
       const thunk = actionCreators.retrieveTransactions();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       expect(req).to.be.instanceof(this.FakeXMLHttpRequest);
-      expect(req.url).to.equal('/api/transactions');
+      expect(req.url).to.equal('/api/transactions?filter[user]=100');
       expect(req.method).to.equal('GET');
     });
 
     it('should respond appropriately when there are no errors', () => {
       const thunk = actionCreators.retrieveTransactions();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       const respBody = JSON.stringify({
         data: [
           {id: 1},
@@ -186,7 +238,7 @@ describe('transactions/actionCreators', function() {
 
     it('should respond appropriately when aborted', () => {
       const thunk = actionCreators.retrieveTransactions();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.abort();
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.have.been.calledWith({
@@ -199,7 +251,7 @@ describe('transactions/actionCreators', function() {
 
     it('should respond appropriately when a error status code is returned', () => {
       const thunk = actionCreators.retrieveTransactions();
-      const req = thunk(this.dispatch);
+      const req = thunk(this.dispatch, this.getState);
       req.respond(500);
       expect(this.dispatch).to.have.been.calledTwice;
       expect(this.dispatch).to.not.have.been.calledWith({


### PR DESCRIPTION
Resolves #329 

---

This makes it so categories and transactions are scoped to the logged-in user. There's no security yet, though (you can just make requests for other people's stuff atm). I'm thinking that Fortune's input/output hooks are where I'll need to add those checks.