### PR TITLE
Add anti-CSRF token to requests; add default XHR headers module

### DIFF
--- a/client/common/services/default-xhr-headers.js
+++ b/client/common/services/default-xhr-headers.js
@@ -1,0 +1,10 @@
+import cookies from 'cookiesjs';
+
+// Include these in all requests by default
+export default {
+  // This isn't used for GET requests, but to keep it simple we just send it
+  // along anyway.
+  'X-CSRF-Token': cookies('antiCsrfToken'),
+  // Required for JSON API
+  'Content-Type': 'application/vnd.api+json'
+};

--- a/client/state/categories/action-creators.js
+++ b/client/state/categories/action-creators.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import xhr from 'xhr';
 import actionTypes from './action-types';
 import authActionTypes from '../auth/action-types';
+import defaultXhrHeaders from '../../common/services/default-xhr-headers';
 
 export function resetCreateCategoryResolution() {
   return {
@@ -25,9 +26,7 @@ export function createCategory(resource) {
         body: JSON.stringify({
           data: resource
         }),
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res, body) => {
         if (req.aborted) {
@@ -70,9 +69,7 @@ export function retrieveCategories() {
     const req = xhr.get(
       `/api/categories?filter[user]=${userId}`,
       {
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res, body) => {
         if (req.aborted) {
@@ -119,9 +116,7 @@ export function updateCategory(resource) {
       `/api/categories/${id}`,
       {
         body: JSON.stringify({data: resource}),
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res) => {
         if (req.aborted) {
@@ -167,9 +162,7 @@ export function deleteCategory(categoryId) {
     const req = xhr.del(
       `/api/categories/${categoryId}`,
       {
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res) => {
         if (req.aborted) {

--- a/client/state/contact/action-creators.js
+++ b/client/state/contact/action-creators.js
@@ -1,6 +1,7 @@
 import xhr from 'xhr';
 import actionTypes from './action-types';
 import authActionTypes from '../auth/action-types';
+import defaultXhrHeaders from '../../common/services/default-xhr-headers';
 
 export function sendMessage(data) {
   return (dispatch) => {
@@ -10,9 +11,7 @@ export function sendMessage(data) {
       '/help/messages',
       {
         body: JSON.stringify(data),
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res) => {
         if (req.aborted) {

--- a/client/state/transactions/action-creators.js
+++ b/client/state/transactions/action-creators.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import xhr from 'xhr';
 import actionTypes from './action-types';
 import authActionTypes from '../auth/action-types';
+import defaultXhrHeaders from '../../common/services/default-xhr-headers';
 
 export function resetCreateTransactionResolution() {
   return {
@@ -26,9 +27,7 @@ export function createTransaction(resource) {
         body: JSON.stringify({
           data: resource
         }),
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res, body) => {
         if (req.aborted) {
@@ -68,9 +67,7 @@ export function retrieveTransactions() {
     const req = xhr.get(
       `/api/transactions?filter[user]=${userId}`,
       {
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res, body) => {
         if (req.aborted) {
@@ -117,9 +114,7 @@ export function updateTransaction(resource) {
       `/api/transactions/${id}`,
       {
         body: JSON.stringify({data: resource}),
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res) => {
         if (req.aborted) {
@@ -163,9 +158,7 @@ export function deleteTransaction(id) {
     const req = xhr.del(
       `/api/transactions/${id}`,
       {
-        headers: {
-          'Content-Type': 'application/vnd.api+json'
-        }
+        headers: {...defaultXhrHeaders}
       },
       (err, res) => {
         if (req.aborted) {

--- a/package.json
+++ b/package.json
@@ -103,6 +103,8 @@
     "connect-ensure-login": "0.1.1",
     "connect-pg-simple": "3.1.0",
     "cookie-parser": "1.4.3",
+    "cookiesjs": "1.4.2",
+    "csurf": "1.9.0",
     "dotenv": "2.0.0",
     "express": "4.14.0",
     "express-request-id": "1.1.0",


### PR DESCRIPTION
The Moolah API _may_ not need CSRF at the moment.

- No CORS
- JSON requests only
- GET requests don't manipulate data (well, once #747 is resolved)
- the endpoints only accept the JSON API content-type header

All of these make XSS attacks more difficult. But I'm adding these tokens anyway, because they're not a perf hit, they're more secure than relying on a series of things that happen to be true now, and lastly, things may change in the future.