### PR TITLE
Begin adding some security to profiles

### DIFF
--- a/server/store.js
+++ b/server/store.js
@@ -9,22 +9,72 @@ const resources = {
     label: String,
     emoji: String,
     transactions: [Array('transaction'), 'category'],
-    user: 'user_account'
+    user: 'profile'
   },
   transaction: {
     description: String,
     value: Number,
     date: String,
     category: ['category', 'transactions'],
-    user: 'user_account'
+    user: 'profile'
   },
-  user_account: {
-    google_id: String
+  profile: {
+    // Just for display purposes. Whether or not they have a name doesn't really
+    // matter.
+    name: String,
+    email: String,
+    // This is only set if the user has configured a local login
+    password: String,
+
+    // Our social login fields
+    google_id: String,
+    google_token: String,
+    twitter_id: String,
+    twitter_token: String,
+    facebook_id: String,
+    facebook_token: String,
+    github_id: String,
+    github_token: String,
   }
 };
 
-const options = {
-  adapter: [postgresAdapter, {url: dbConfig}]
+const hooks = {
+  profile: [
+    null,
+    // Output hook: ensures only "name" and "email" are returned for the user
+    (context, record) => {
+      delete record.password;
+      delete record.google_id;
+      delete record.google_token;
+      delete record.facebook_id;
+      delete record.facebook_token;
+      delete record.twitter_id;
+      delete record.twitter_token;
+      delete record.github_id;
+      delete record.github_token;
+    }
+  ]
 };
 
-module.exports = fortune(resources, options);
+const options = {
+  adapter: [postgresAdapter, {url: dbConfig}],
+  hooks
+};
+
+const store = fortune(resources, options);
+
+var originalRequest = store.request;
+store.request = function(options) {
+  const {type, method, ids} = options;
+
+  const isReadOne = method === 'find' && ids;
+  // Users are only permitted to read a single profile at a time (their own!)
+  if (type === 'profile' && !isReadOne) {
+    const err = new fortune.errors.MethodError('Method not permitted.');
+    return Promise.reject(err);
+  }
+
+  return originalRequest.call(this, options);
+};
+
+module.exports = store;

--- a/server/util/configure-passport.js
+++ b/server/util/configure-passport.js
@@ -13,7 +13,7 @@ function createId() {
 }
 
 function findUser(db, googleId) {
-  return db.one(`SELECT * FROM user_account WHERE google_id=$[googleId]`, {googleId});
+  return db.one(`SELECT * FROM profile WHERE google_id=$[googleId]`, {googleId});
 }
 
 module.exports = function(db) {
@@ -30,8 +30,11 @@ module.exports = function(db) {
           const errorKey = _.findKey(queryErrorCode, c => c === err.code);
 
           if (errorKey === 'noData') {
-            const query = baseSql.create('user_account', ['id', 'google_id']);
-            db.one(query, {google_id: googleId, id: createId()})
+            const query = baseSql.create('profile', ['id', 'google_id']);
+            db.one(query, {
+              google_token: accessToken,
+              google_id: googleId, id: createId()
+            })
               .then(result => {
                 return done(null, result);
               }, () => {
@@ -61,7 +64,7 @@ module.exports = function(db) {
 
   // Retrieves a user account from the DB
   passport.deserializeUser((id, done) => {
-    const readQuery = baseSql.read('user_account', ['id'], {
+    const readQuery = baseSql.read('profile', ['id'], {
       singular: true
     });
     db.one(readQuery, {id})


### PR DESCRIPTION
- Rename "user_accounts" to "profiles," so that they are accessible
  over the JSON API that Fortune produces (fortune does not like
  underscores)
- Only return id, name, and email from user accounts
- Prevent all CRUD methods except for readOne for user accounts

I still need to make sure that you're logged in as the specified
user before returning the data, which is obv. quite important :)