### PR TITLE
Generate uuid's for resource Ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "redux-thunk": "2.1.0",
     "serve-favicon": "2.3.0",
     "throng": "4.0.0",
+    "uuid": "3.0.1",
     "xhr": "2.2.2"
   }
 }

--- a/server/store.js
+++ b/server/store.js
@@ -2,6 +2,7 @@
 
 const fortune = require('fortune');
 const postgresAdapter = require('fortune-postgres');
+const uuid = require('uuid/v4');
 const dbConfig = require('../config/db-config');
 
 const resources = {
@@ -76,7 +77,15 @@ const hooks = {
 };
 
 const options = {
-  adapter: [postgresAdapter, {url: dbConfig}],
+  adapter: [
+    postgresAdapter,
+    {
+      url: dbConfig,
+      generatePrimaryKey() {
+        return uuid();
+      }
+    }
+  ],
   hooks
 };
 


### PR DESCRIPTION
Fortune-postgres base64 encodes the IDs it generates (for now), which aren't URL-safe. Switching to uuid's fixes the problem