### PR TITLE
Dropdown overlay

### DIFF
--- a/client/common/components/dropdown-overlay.css
+++ b/client/common/components/dropdown-overlay.css
@@ -5,4 +5,10 @@
   right: 0;
   bottom: 0;
   z-index: $zIndex-overlay;
+  pointer-events: none;
+  transform: translateZ(0);
+}
+
+.dropdownOverlay-visible {
+  pointer-events: all;
 }

--- a/client/common/components/dropdown-overlay.js
+++ b/client/common/components/dropdown-overlay.js
@@ -1,12 +1,15 @@
 import React from 'react';
+import classNames from 'classnames';
 
 const noop = () => {
   // Intentionally left blank
 };
 
-export default function DropdownOverlay({onClick}) {
+export default function DropdownOverlay({onClick, visible}) {
   let clickHandler = onClick ? onClick : noop;
+  const classes = classNames('dropdownOverlay', {'dropdownOverlay-visible': visible});
+
   return (
-    <div className="dropdownOverlay" onClick={clickHandler}/>
+    <div className={classes} onClick={clickHandler}/>
   );
 }

--- a/client/header/components/profile-dropdown.css
+++ b/client/header/components/profile-dropdown.css
@@ -9,27 +9,16 @@
   border-radius: 6px;
   overflow: hidden;
   transition: transform 130ms ease-in, opacity 130ms ease-in;
-  transform: translateY(0);
-  opacity: 1;
-}
-
-.profileDropdown-enter .profileDropdown,
-.profileDropdown-appear .profileDropdown {
   transform: translateY(-10px);
   opacity: 0;
+  pointer-events: none;
+  will-change: opacity, transform;
 }
 
-.profileDropdown-enter.profileDropdown-enter-active .profileDropdown,
-.profileDropdown-appear.profileDropdown-appear-active .profileDropdown,
-.profileDropdown-leave .profileDropdown {
-  transform: translateY(0);
+.profileDropdown-visible {
+  pointer-events: all;
   opacity: 1;
-  transition: transform 130ms ease-out, opacity 130ms ease-out;
-}
-
-.profileDropdown-leave.profileDropdown-leave-active .profileDropdown {
-  transform: translateY(-10px);
-  opacity: 0;
+  transform: translateY(0);
 }
 
 .profileDropdown-listItem {

--- a/client/header/components/profile-dropdown.js
+++ b/client/header/components/profile-dropdown.js
@@ -1,7 +1,7 @@
 import React, {Component} from 'react';
 import {Link} from 'react-router';
+import classNames from 'classnames';
 import xhr from 'xhr';
-import ReactCSSTransitionGroup from '../../vendor/css-transition-group';
 import defaultXhrHeaders from '../../common/utils/default-xhr-headers';
 import DropdownOverlay from '../../common/components/dropdown-overlay';
 
@@ -10,43 +10,36 @@ export default class ProfileDropdown extends Component {
     const {closeDropdown} = this.props;
     const {displayDropdown} = this.state;
 
+    const classes = classNames('profileDropdown', {'profileDropdown-visible': displayDropdown});
+
     return (
-      <ReactCSSTransitionGroup
-        transitionName="profileDropdown"
-        transitionAppear={true}
-        transitionAppearTimeout={130}
-        transitionEnterTimeout={130}
-        transitionLeaveTimeout={130}>
-        {displayDropdown && (
-          <div className="profileDropdown_container">
-            <ul className="profileDropdown">
-              <li className="profileDropdown-listItem">
-                <Link
-                  to="/account"
-                  className="profileDropdown-link"
-                  onClick={closeDropdown}>
-                  <i className="zmdi zmdi-account profileDropdown-icon"/>
-                  Account settings
-                </Link>
-              </li>
-              <li className="profileDropdown-listItem">
-                <form
-                  acceptCharset="UTF-8"
-                  action="/logout"
-                  method="post"
-                  ref={(ref) => {this.form = ref;}}
-                  onSubmit={this.onSubmit}>
-                  <button type="submit" className="profileDropdown-link profileDropdown-btn">
-                    <i className="zmdi zmdi-power profileDropdown-icon"/>
-                    Sign out
-                  </button>
-                </form>
-              </li>
-            </ul>
-            <DropdownOverlay onClick={closeDropdown}/>
-          </div>
-        )}
-      </ReactCSSTransitionGroup>
+      <div>
+        <ul className={classes}>
+          <li className="profileDropdown-listItem">
+            <Link
+              to="/account"
+              className="profileDropdown-link"
+              onClick={closeDropdown}>
+              <i className="zmdi zmdi-account profileDropdown-icon"/>
+              Account settings
+            </Link>
+          </li>
+          <li className="profileDropdown-listItem">
+            <form
+              acceptCharset="UTF-8"
+              action="/logout"
+              method="post"
+              ref={(ref) => {this.form = ref;}}
+              onSubmit={this.onSubmit}>
+              <button type="submit" className="profileDropdown-link profileDropdown-btn">
+                <i className="zmdi zmdi-power profileDropdown-icon"/>
+                Sign out
+              </button>
+            </form>
+          </li>
+        </ul>
+        <DropdownOverlay visible={displayDropdown} onClick={closeDropdown}/>
+      </div>
     );
   }
 


### PR DESCRIPTION
Showing the profile dropdown used to involve lots of paints: the whole screen for the overlay, then the dropdown as it animated in.

This makes it so there are 0 paints for the dropdown appearing/hiding. This same technique will be applied to the modal and the resource lists so that the main transitions in the app are all 0 paints 👌 